### PR TITLE
Fix activation parse error in plugin

### DIFF
--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -25,9 +25,6 @@ final class WCOF_Plugin {
         $self = new self();
         $self->register_sw_rewrite();
         if( !get_option('wcof_setup_done') ) add_option('wcof_setup_done', 0);
-        flush_rewrite_rules();
-    }
-    public static function deactivate(){ flush_rewrite_rules(); }
         add_role('rider', 'Rider', ['read'=>true,'wcof_rider'=>true]);
         flush_rewrite_rules();
     }


### PR DESCRIPTION
## Summary
- Move `add_role()` call into plugin activation routine and consolidate deactivation logic

## Testing
- `php -l wc-order-flow.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab00b504c48332a9941183d7b9f037