### PR TITLE
Add active/inactive toggle to product manager

### DIFF
--- a/assets/product-manager.js
+++ b/assets/product-manager.js
@@ -14,7 +14,7 @@
     return fetch(apiRoot + 'products/categories?per_page=100',{headers}).then(r=>r.json());
   }
   function fetchProducts(){
-    return fetch(apiRoot + 'products?per_page=100',{headers}).then(r=>r.json());
+    return fetch(apiRoot + 'products?per_page=100&status=any',{headers}).then(r=>r.json());
   }
 
   function render(){
@@ -69,10 +69,25 @@
     div.className='wcof-prod';
     const title = document.createElement('div');
     title.textContent = p.name + ' - ' + p.price;
+    const toggleLabel = document.createElement('label');
+    toggleLabel.style.display='flex';
+    toggleLabel.style.alignItems='center';
+    toggleLabel.style.gap='4px';
+    const toggle = document.createElement('input');
+    toggle.type='checkbox';
+    toggle.checked = p.status === 'publish';
+    toggle.addEventListener('change', function(){
+      const status = toggle.checked ? 'publish' : 'draft';
+      fetch(apiRoot+'products/'+p.id,{method:'PUT',headers,body:JSON.stringify({status})}).then(render);
+    });
+    toggleLabel.appendChild(toggle);
+    toggleLabel.appendChild(document.createTextNode('Active'));
     const edit = document.createElement('button');
     edit.textContent='Edit';
     edit.addEventListener('click', function(){ openForm(p); });
-    div.appendChild(title); div.appendChild(edit);
+    div.appendChild(title);
+    div.appendChild(toggleLabel);
+    div.appendChild(edit);
     return div;
   }
 

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -3,7 +3,7 @@
  * Plugin Name: Reeservafood
  * Description: App‑style order approvals for WooCommerce with ETA, “Rider on the way”, live order board, and integrated OneSignal Web Push (no extra plugin). Mobile‑first UI.
  * Author: Reeserva
- * Version: 1.9.0
+ * Version: 1.9.1
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * License: GPLv2 or later
@@ -522,7 +522,7 @@ final class WCOF_Plugin {
     /* ===== Product manager (front) ===== */
     public function shortcode_product_manager($atts=[]){
         if(!current_user_can('manage_woocommerce')) return '';
-        wp_enqueue_script('wcof-product-manager', plugins_url('assets/product-manager.js', __FILE__), [], '1.9.0', true);
+        wp_enqueue_script('wcof-product-manager', plugins_url('assets/product-manager.js', __FILE__), [], '1.9.1', true);
         wp_localize_script('wcof-product-manager', 'WCOF_PM', [
             'root'  => esc_url_raw( rest_url('wc/v3/') ),
             'nonce' => wp_create_nonce('wp_rest')
@@ -533,7 +533,7 @@ final class WCOF_Plugin {
           .wcof-cat{border:1px solid #e5e7eb;border-radius:12px;overflow:hidden}
           .wcof-cat-header{display:flex;justify-content:space-between;align-items:center;background:#f1f5f9;padding:10px;font-weight:600}
           .wcof-prod-list{display:flex;flex-direction:column;gap:8px;padding:10px}
-          .wcof-prod{display:flex;justify-content:space-between;align-items:center;background:#fff;border:1px solid #e5e7eb;border-radius:8px;padding:8px}
+          .wcof-prod{display:flex;justify-content:space-between;align-items:center;gap:8px;background:#fff;border:1px solid #e5e7eb;border-radius:8px;padding:8px}
           .wcof-prod-form{display:flex;flex-direction:column;gap:10px}
           .wcof-prod-form input,.wcof-prod-form textarea,.wcof-prod-form select{width:100%;padding:8px;border:1px solid #cbd5e1;border-radius:6px}
           .wcof-prod-form button{padding:10px;background:#111;color:#fff;border:none;border-radius:6px}


### PR DESCRIPTION
## Summary
- allow admins to toggle product availability directly from the product manager
- display inactive products by retrieving all statuses
- bump plugin version and tweak layout spacing

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/product-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab1dbd0190833290ee74dd4dd173f3