### PR TITLE
Improve delivery and completion actions

### DIFF
--- a/assets/orders-admin.js
+++ b/assets/orders-admin.js
@@ -21,7 +21,7 @@
               <button class="btn btn-approve" data-action="approve" data-url="${htmlEscape(o.approve_url||'')}">Approva</button>
               <button class="btn btn-reject" data-action="reject" data-url="${htmlEscape(o.reject_url||'')}">Rifiuta</button>`;
     } else if(o.status==='wc-processing'){
-      return `<a class="btn btn-complete" data-action="out" href="${htmlEscape(o.out_url||'')}">In Consegna</a>`;
+      return `<a class="btn btn-out" data-action="out" data-complete-url="${htmlEscape(o.complete_url||'')}" href="${htmlEscape(o.out_url||'')}">In Consegna</a>`;
     } else if(o.status==='wc-out-for-delivery'){
       return `<a class="btn btn-complete" data-action="complete" href="${htmlEscape(o.complete_url||'')}">Complete</a>`;
     }
@@ -96,12 +96,34 @@
       window.location.href = (t.getAttribute('data-url')||t.dataset.url||'').replace(/&amp;/g,'&');
     }
     if(t.dataset && t.dataset.action==='out'){
-      if(!confirm('Segnare come "In consegna"?')) { e.preventDefault(); return; }
-      t.setAttribute('href', (t.getAttribute('href')||'').replace(/&amp;/g,'&'));
+      e.preventDefault();
+      if(!confirm('Segnare come "In consegna"?')) return;
+      const url = (t.getAttribute('href')||'').replace(/&amp;/g,'&');
+      fetch(url, {credentials:'include'}).then(()=>{
+        const card = t.closest('.wcof-card');
+        if(card){
+          card.setAttribute('data-status','wc-out-for-delivery');
+          const left = card.querySelector('.wcof-left');
+          if(left){ left.classList.remove('st-proc'); left.classList.add('st-out'); }
+          const badge = card.querySelector('.wcof-badge');
+          if(badge) badge.textContent = 'wc-out-for-delivery';
+          t.textContent = 'Complete';
+          t.classList.remove('btn-out');
+          t.classList.add('btn-complete');
+          t.dataset.action = 'complete';
+          const cu = t.dataset.completeUrl || '';
+          t.setAttribute('href', cu.replace(/&amp;/g,'&'));
+        }
+      }).catch(()=>{ window.location.href = url; });
     }
     if(t.dataset && t.dataset.action==='complete'){
-      if(!confirm('Segnare come "Completato"?')) { e.preventDefault(); return; }
-      t.setAttribute('href', (t.getAttribute('href')||'').replace(/&amp;/g,'&'));
+      e.preventDefault();
+      if(!confirm('Segnare come "Completato"?')) return;
+      const url = (t.getAttribute('href')||'').replace(/&amp;/g,'&');
+      fetch(url, {credentials:'include'}).then(()=>{
+        const card = t.closest('.wcof-card');
+        if(card) card.remove();
+      }).catch(()=>{ window.location.href = url; });
     }
   });
 })();

--- a/assets/product-manager.js
+++ b/assets/product-manager.js
@@ -24,6 +24,7 @@
       root.innerHTML='';
       const addCat = document.createElement('button');
       addCat.textContent = '+ Category';
+      addCat.className = 'btn btn-add';
       addCat.addEventListener('click', addCategory);
       root.appendChild(addCat);
       cats.forEach(function(cat){
@@ -31,9 +32,12 @@
         catDiv.className='wcof-cat';
         const head = document.createElement('div');
         head.className='wcof-cat-header';
-        head.textContent = cat.name;
+        const title = document.createElement('span');
+        title.textContent = cat.name;
+        head.appendChild(title);
         const delBtn = document.createElement('button');
         delBtn.textContent='Delete';
+        delBtn.className='btn btn-del';
         delBtn.addEventListener('click', function(){ deleteCategory(cat.id, cat.count); });
         head.appendChild(delBtn);
         catDiv.appendChild(head);
@@ -44,6 +48,7 @@
         });
         const addProd = document.createElement('button');
         addProd.textContent='+ Product';
+        addProd.className='btn btn-add';
         addProd.addEventListener('click', function(){ openForm(null, cat.id); });
         list.appendChild(addProd);
         catDiv.appendChild(list);
@@ -67,26 +72,36 @@
   function productCard(p){
     const div = document.createElement('div');
     div.className='wcof-prod';
+
     const title = document.createElement('div');
+    title.className='wcof-prod-title';
     title.textContent = p.name + ' - ' + p.price;
-    const toggleLabel = document.createElement('label');
-    toggleLabel.style.display='flex';
-    toggleLabel.style.alignItems='center';
-    toggleLabel.style.gap='4px';
-    const toggle = document.createElement('input');
-    toggle.type='checkbox';
-    toggle.checked = p.status === 'publish';
-    toggle.addEventListener('change', function(){
-      const status = toggle.checked ? 'publish' : 'draft';
+
+    const active = document.createElement('div');
+    active.className='wcof-active';
+    const toggle = document.createElement('label');
+    toggle.className='wcof-switch';
+    const cb = document.createElement('input');
+    cb.type='checkbox';
+    cb.checked = p.status === 'publish';
+    cb.addEventListener('change', function(){
+      const status = cb.checked ? 'publish' : 'draft';
       fetch(apiRoot+'products/'+p.id,{method:'PUT',headers,body:JSON.stringify({status})}).then(render);
     });
-    toggleLabel.appendChild(toggle);
-    toggleLabel.appendChild(document.createTextNode('Active'));
+    const span = document.createElement('span'); span.className='wcof-slider';
+    toggle.appendChild(cb);
+    toggle.appendChild(span);
+    active.appendChild(toggle);
+    const activeTxt = document.createElement('span'); activeTxt.textContent='Active';
+    active.appendChild(activeTxt);
+
     const edit = document.createElement('button');
     edit.textContent='Edit';
+    edit.className='btn btn-edit';
     edit.addEventListener('click', function(){ openForm(p); });
+
     div.appendChild(title);
-    div.appendChild(toggleLabel);
+    div.appendChild(active);
     div.appendChild(edit);
     return div;
   }

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -431,7 +431,7 @@ final class WCOF_Plugin {
           .wcof-actions{display:flex;gap:8px;flex-wrap:wrap;justify-self:end}
           .wcof-eta{width:90px;border:1px solid var(--wcf-border);border-radius:10px;padding:.55rem .6rem}
           .btn{border:none;border-radius:12px;padding:.6rem .9rem;font-weight:700;color:#fff;cursor:pointer}
-          .btn-approve{background:#2563eb} .btn-reject{background:#94a3b8} .btn-complete{background:#10b981}
+          .btn-approve{background:#2563eb} .btn-reject{background:#94a3b8} .btn-out{background:#f59e0b} .btn-complete{background:#10b981}
           .wcof-items{padding:12px 16px;background:#f9fafb;border-top:1px dashed var(--wcf-border)}
           .wcof-info{margin-top:8px;font-size:14px;color:#334155}
           .wcof-info div{margin-top:4px}
@@ -475,7 +475,7 @@ final class WCOF_Plugin {
                   <button class="btn btn-approve" data-action="approve" data-url="<?php echo esc_attr( wp_nonce_url(admin_url('admin-post.php?action=wcof_approve&order_id='.$id),'wcof_approve_'.$id) ); ?>">Approva</button>
                   <button class="btn btn-reject" data-action="reject" data-url="<?php echo esc_attr( wp_nonce_url(admin_url('admin-post.php?action=wcof_reject&order_id='.$id),'wcof_reject_'.$id) ); ?>">Rifiuta</button>
                 <?php elseif($status==='wc-processing'): ?>
-                  <a class="btn btn-complete" data-action="out" href="<?php echo esc_attr( wp_nonce_url(admin_url('admin-post.php?action=wcof_out_for_delivery&order_id='.$id),'wcof_out_for_delivery_'.$id) ); ?>">In Consegna</a>
+                  <a class="btn btn-out" data-action="out" data-complete-url="<?php echo esc_attr( wp_nonce_url(admin_url('admin-post.php?action=wcof_complete&order_id='.$id),'wcof_complete_'.$id) ); ?>" href="<?php echo esc_attr( wp_nonce_url(admin_url('admin-post.php?action=wcof_out_for_delivery&order_id='.$id),'wcof_out_for_delivery_'.$id) ); ?>">In Consegna</a>
                 <?php elseif($status===self::STATUS_OUT_FOR_DELIVERY): ?>
                   <a class="btn btn-complete" data-action="complete" href="<?php echo esc_attr( wp_nonce_url(admin_url('admin-post.php?action=wcof_complete&order_id='.$id),'wcof_complete_'.$id) ); ?>">Complete</a>
                 <?php else: ?><em style="color:#94a3b8">—</em><?php endif; ?>
@@ -529,14 +529,27 @@ final class WCOF_Plugin {
         ]);
         ob_start(); ?>
         <style>
-          #wcof-product-manager{font-family:sans-serif;display:flex;flex-direction:column;gap:20px}
-          .wcof-cat{border:1px solid #e5e7eb;border-radius:12px;overflow:hidden}
-          .wcof-cat-header{display:flex;justify-content:space-between;align-items:center;background:#f1f5f9;padding:10px;font-weight:600}
-          .wcof-prod-list{display:flex;flex-direction:column;gap:8px;padding:10px}
-          .wcof-prod{display:flex;justify-content:space-between;align-items:center;gap:8px;background:#fff;border:1px solid #e5e7eb;border-radius:8px;padding:8px}
+          :root{--wcf-card:#ffffff;--wcf-border:#e5e7eb;--wcf-shadow:0 6px 24px rgba(15,23,42,.06);}
+          #wcof-product-manager{font-family:sans-serif;display:flex;flex-direction:column;gap:18px}
+          .wcof-cat{background:var(--wcf-card);border:1px solid var(--wcf-border);border-radius:18px;box-shadow:var(--wcf-shadow);overflow:hidden}
+          .wcof-cat-header{display:flex;justify-content:space-between;align-items:center;padding:14px;background:#f8fafc;font-weight:700}
+          .wcof-prod-list{display:flex;flex-direction:column;gap:10px;padding:14px;background:#f9fafb;border-top:1px dashed var(--wcf-border)}
+          .wcof-prod{display:flex;justify-content:space-between;align-items:center;gap:12px;background:#fff;border:1px solid var(--wcf-border);border-radius:12px;padding:10px}
+          .wcof-prod-title{font-weight:600}
+          .wcof-active{display:flex;align-items:center;gap:6px}
+          .btn{border:none;border-radius:12px;padding:.55rem .9rem;font-weight:700;color:#fff;cursor:pointer}
+          .btn-add{background:#2563eb}
+          .btn-del{background:#ef4444}
+          .btn-edit{background:#10b981}
           .wcof-prod-form{display:flex;flex-direction:column;gap:10px}
           .wcof-prod-form input,.wcof-prod-form textarea,.wcof-prod-form select{width:100%;padding:8px;border:1px solid #cbd5e1;border-radius:6px}
           .wcof-prod-form button{padding:10px;background:#111;color:#fff;border:none;border-radius:6px}
+          .wcof-switch{position:relative;display:inline-block;width:40px;height:22px}
+          .wcof-switch input{opacity:0;width:0;height:0}
+          .wcof-slider{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background:#cbd5e1;transition:.2s;border-radius:22px}
+          .wcof-slider:before{position:absolute;content:"";height:18px;width:18px;left:2px;bottom:2px;background:#fff;transition:.2s;border-radius:50%}
+          .wcof-switch input:checked + .wcof-slider{background:#22c55e}
+          .wcof-switch input:checked + .wcof-slider:before{transform:translateX(18px)}
           @media(min-width:480px){.wcof-prod-form{max-width:420px;margin:0 auto}}
         </style>
         <div id="wcof-product-manager"></div>


### PR DESCRIPTION
## Summary
- Color "In Consegna" button orange and "Complete" button green
- Update delivery and completion actions via fetch to avoid redirects
- Restyle product manager with card layout, colored buttons, and on/off switch

## Testing
- `node --check assets/orders-admin.js`
- `node --check assets/product-manager.js`
- `php -l wc-order-flow.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac4060d97c8332aa6729d419770d1d