### PR TITLE
Fix order arrival time and allow ETA adjustments

### DIFF
--- a/assets/orders-admin.js
+++ b/assets/orders-admin.js
@@ -21,7 +21,9 @@
               <button class="btn btn-approve" data-action="approve" data-url="${htmlEscape(o.approve_url||'')}">Approva</button>
               <button class="btn btn-reject" data-action="reject" data-url="${htmlEscape(o.reject_url||'')}">Rifiuta</button>`;
     } else if(o.status==='wc-processing'){
-      return `<a class="btn btn-out" data-action="out" data-complete-url="${htmlEscape(o.complete_url||'')}" href="${htmlEscape(o.out_url||'')}">In Consegna</a>`;
+      return `<input type="number" min="0" step="1" placeholder="ETA min" value="${htmlEscape(o.eta||'')}" class="wcof-eta">
+              <button class="btn btn-approve" data-action="approve" data-url="${htmlEscape(o.set_eta_url||'')}">Aggiorna ETA</button>
+              <a class="btn btn-out" data-action="out" data-complete-url="${htmlEscape(o.complete_url||'')}" href="${htmlEscape(o.out_url||'')}">In Consegna</a>`;
     } else if(o.status==='wc-out-for-delivery'){
       return `<a class="btn btn-complete" data-action="complete" href="${htmlEscape(o.complete_url||'')}">Complete</a>`;
     }


### PR DESCRIPTION
## Summary
- keep thank-you status hero at top of order received page
- store and expose fixed arrival timestamps; allow admins to update ETA until delivery
- show stored arrival on order board and thank-you hero

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/orders-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac70ef4d2c8332b86cd328af650740