### PR TITLE
Ensure WCPay capture defers until approval

### DIFF
--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -186,8 +186,9 @@ final class WCOF_Plugin {
     }
 
     public function maybe_defer_wcpay_capture($manual, $order){
-        if(!$order instanceof WC_Order || !$order->get_meta(self::META_DECIDED)) return true;
-        return $manual;
+        if(!$order instanceof WC_Order) return $manual;
+        if($order->get_meta(self::META_DECIDED)) return $manual;
+        return true;
     }
 
     public function maybe_defer_paypal_capture($arg, $order){


### PR DESCRIPTION
## Summary
- Avoid forcing manual capture when an order is missing or already decided
- Confirm Stripe and PayPal gateways hook into manual/authorization capture

## Testing
- `php -l wc-order-flow.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac98d730708332a2c99c78ac4dcc69