### PR TITLE
Add map-based delivery address field with postal code restrictions

### DIFF
--- a/assets/checkout-address.js
+++ b/assets/checkout-address.js
@@ -104,9 +104,9 @@
             placeMarker(e.latlng.lat, e.latlng.lng);
         });
 
-        var wrapper=document.querySelector('.woocommerce-billing-fields__field-wrapper');
-        if(wrapper) wrapper.style.display='none';
         var heading=document.querySelector('.woocommerce-billing-fields > h3');
         if(heading) heading.style.display='none';
+        var ship=document.querySelector('.woocommerce-shipping-fields');
+        if(ship) ship.style.display='none';
     });
 })();


### PR DESCRIPTION
## Summary
- show a single delivery address field with map autocomplete in checkout
- hide standard billing/shipping fields to rely on the map address
- validate and store delivery address, enforcing allowed postal codes

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/checkout-address.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad050768c48332934613aab502cafc