### PR TITLE
Add map-based delivery address field with postal code restrictions

### DIFF
--- a/assets/checkout-address.js
+++ b/assets/checkout-address.js
@@ -1,6 +1,6 @@
 (function(){
     if(typeof wcofCheckoutAddress === 'undefined') return;
-    document.addEventListener('DOMContentLoaded', function(){
+    function init(){
         var allowed = wcofCheckoutAddress.postalCodes || [];
         var input = document.querySelector('#wcof_delivery_address');
         if(!input) return;
@@ -104,9 +104,14 @@
             placeMarker(e.latlng.lat, e.latlng.lng);
         });
 
-        var wrapper=document.querySelector('.woocommerce-billing-fields__field-wrapper');
-        if(wrapper) wrapper.style.display='none';
         var heading=document.querySelector('.woocommerce-billing-fields > h3');
         if(heading) heading.style.display='none';
-    });
+        var ship=document.querySelector('.woocommerce-shipping-fields');
+        if(ship) ship.style.display='none';
+    }
+    if(document.readyState==='loading'){
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
 })();


### PR DESCRIPTION
## Summary
- show a single delivery address field with map autocomplete in checkout
- hide standard billing/shipping fields to rely on the map address
- validate and store delivery address, enforcing allowed postal codes
- ensure checkout script executes even if loaded after DOM ready so map and marker render

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/checkout-address.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad050768c48332934613aab502cafc