### PR TITLE
Add Reactivate plugin with Gutenpride dependency check

### DIFF
--- a/gutenpride/gutenpride.php
+++ b/gutenpride/gutenpride.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Gutenpride dependency stub.
+ *
+ * This file is bundled with the plugin so that Reactivate can
+ * safely load its required functionality without relying on an
+ * external package. Developers can replace this stub with the
+ * real implementation as needed.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function gutenpride_init() {
+    // Placeholder function for the bundled dependency.
+}

--- a/reactivate/reactivate.php
+++ b/reactivate/reactivate.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Plugin Name: Reactivate
+ * Description: Demonstration plugin that requires the bundled Gutenpride dependency.
+ * Version: 1.0.0
+ * Author: Example
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Ensure Gutenpride dependency is present during activation.
+ */
+function reactivate_activate() {
+    $dependency = plugin_dir_path( __FILE__ ) . '../gutenpride/gutenpride.php';
+
+    if ( file_exists( $dependency ) ) {
+        require $dependency;
+    } else {
+        wp_die(
+            sprintf(
+                esc_html__( 'Reactivate requires the Gutenpride dependency. Please make sure the file %s exists.', 'reactivate' ),
+                '<code>' . esc_html( $dependency ) . '</code>'
+            ),
+            esc_html__( 'Missing Dependency', 'reactivate' ),
+            [ 'back_link' => true ]
+        );
+    }
+}
+register_activation_hook( __FILE__, 'reactivate_activate' );
+
+// Attempt to load the dependency on regular execution as well to prevent fatal errors.
+$gutenpride = plugin_dir_path( __FILE__ ) . '../gutenpride/gutenpride.php';
+if ( file_exists( $gutenpride ) ) {
+    require_once $gutenpride;
+} else {
+    add_action(
+        'admin_notices',
+        function () use ( $gutenpride ) {
+            printf(
+                '<div class="notice notice-error"><p>%s</p></div>',
+                esc_html( sprintf( 'Reactivate requires Gutenpride. Missing file: %s', $gutenpride ) )
+            );
+        }
+    );
+    return;
+}


### PR DESCRIPTION
## Summary
- add Reactivate plugin file that verifies the bundled Gutenpride dependency before activation
- include a stub Gutenpride file to satisfy the dependency

## Testing
- `php -l reactivate/reactivate.php`
- `php -l gutenpride/gutenpride.php`


------
https://chatgpt.com/codex/tasks/task_e_68ada7de29f48332b31314e771d9be75