### PR TITLE
fix: ensure plugin header uses valid characters

### DIFF
--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Reeservafood
- * Description: App‑style order approvals for WooCommerce with ETA, “Rider on the way”, live order board, and integrated OneSignal Web Push (no extra plugin). Mobile‑first UI.
+ * Description: App-style order approvals for WooCommerce with ETA, "Rider on the way", live order board, and integrated OneSignal Web Push (no extra plugin). Mobile-first UI.
  * Author: Reeserva
  * Version: 1.9.1
  * Requires at least: 5.8


### PR DESCRIPTION
## Summary
- replace special characters in plugin header description with plain ASCII to ensure WordPress detects a valid plugin header

## Testing
- `php -l wc-order-flow.php`
- `php -l reactivate/reactivate.php`
- `php -l gutenpride/gutenpride.php`


------
https://chatgpt.com/codex/tasks/task_e_68adbcd060788332a7713df438f6ef57