### PR TITLE
Add plugin header to Gutenpride stub

### DIFF
--- a/gutenpride/gutenpride.php
+++ b/gutenpride/gutenpride.php
@@ -1,5 +1,14 @@
 <?php
 /**
+ * Plugin Name: Gutenpride
+ * Description: Dependency stub for Reactivate.
+ * Version: 1.0.0
+ * Author: Reeserva
+ * License: GPLv2 or later
+ * Text Domain: gutenpride
+ */
+
+/**
  * Gutenpride dependency stub.
  *
  * This file is bundled with the plugin so that Reactivate can


### PR DESCRIPTION
## Summary
- add proper plugin header to Gutenpride dependency stub

## Testing
- `php -l gutenpride/gutenpride.php`


------
https://chatgpt.com/codex/tasks/task_e_68adc11c36ec83328bbe67d2b622d4f6