### PR TITLE
Validate checkout address with map marker

### DIFF
--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -886,6 +886,12 @@ final class WCOF_Plugin {
 
             'label'    => __('Address','wc-order-flow'),
         ], $value);
+        // Hidden field used to prevent checkout unless a valid address
+        // has been selected. It is filled via JS when the marker resolves
+        // to an allowed postal code.
+        echo '<input type="text" id="wcof_delivery_valid" name="wcof_delivery_valid" value="" required style="position:absolute;left:-9999px;width:1px;height:1px;" />';
+        // Allow users to correct the marker position manually.
+        echo '<p class="wcof-move-marker"><a href="#" id="wcof-move-marker">'.esc_html__('Marker is wrong / let me set the marker','wc-order-flow').'</a></p>';
         echo '<div id="wcof-delivery-map" style="height:300px;margin-top:10px"></div>';
         echo '</div>';
     }
@@ -912,8 +918,11 @@ final class WCOF_Plugin {
         $codes = $this->delivery_postal_codes();
         $postcode = isset($_POST['billing_postcode']) ? sanitize_text_field($_POST['billing_postcode']) : '';
         $address  = isset($_POST['wcof_delivery_address']) ? sanitize_text_field($_POST['wcof_delivery_address']) : '';
+        $valid    = isset($_POST['wcof_delivery_valid']) ? sanitize_text_field($_POST['wcof_delivery_valid']) : '';
         if($address===''){
             wc_add_notice(__('Please enter a delivery address.','wc-order-flow'), 'error');
+        }elseif($valid===''){
+            wc_add_notice(__('Please select a valid address from the map.','wc-order-flow'), 'error');
         }elseif( !empty($codes) && !in_array($postcode, $codes, true) ){
             wc_add_notice(__('The address is outside of our delivery area.','wc-order-flow'), 'error');
         }


### PR DESCRIPTION
## Summary
- Require a hidden validity field for checkout and add marker adjustment link
- Update checkout map JS to manage marker dragging and address validation

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/checkout-address.js`


------
https://chatgpt.com/codex/tasks/task_e_68af8a8e827883329a9ceb1ce23b38c8