### PR TITLE
Allow manual marker placement outside delivery area

### DIFF
--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -886,6 +886,9 @@ final class WCOF_Plugin {
 
             'label'    => __('Address','wc-order-flow'),
         ], $value);
+        // Error message container shown when the typed address is
+        // outside the delivery area or cannot be resolved.
+        echo '<p id="wcof-delivery-error" style="color:#dc2626;display:none;margin-top:4px"></p>';
         // Hidden field filled with the resolved address from the map.
         echo '<input type="text" id="wcof_delivery_resolved" name="wcof_delivery_resolved" value="" required style="position:absolute;left:-9999px;width:1px;height:1px;" />';
         // Hidden field used to prevent checkout unless a valid address


### PR DESCRIPTION
## Summary
- Show red error message when typed address is outside delivery area or cannot be resolved
- Let users manually place and confirm a map marker even when geocoding fails

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l wc-order-flow.php`
- `node --check assets/checkout-address.js && echo "JS syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68af91fc14d483328c4f88c2419c8bca