### PR TITLE
Populate WooCommerce state fields from reverse geocode

### DIFF
--- a/assets/checkout-address.js
+++ b/assets/checkout-address.js
@@ -82,15 +82,20 @@
                         showError('Address not in delivery area or not found');
                         if(validInput) validInput.value='';
                         if(resolvedInput) resolvedInput.value='';
+                        document.querySelector('#billing_state').value = '';
+                        document.querySelector('#shipping_state').value = '';
                         return;
                     }
                     hideError();
                     var full = data.display_name || '';
+                    var province = addr.county || addr.state || '';
                     if(resolvedInput) resolvedInput.value = full;
                     document.querySelector('#billing_postcode').value = pc;
                     document.querySelector('#billing_address_1').value = full;
                     document.querySelector('#billing_city').value = addr.city || addr.town || addr.village || '';
                     document.querySelector('#billing_country').value = (addr.country_code || '').toUpperCase();
+                    document.querySelector('#billing_state').value = province;
+                    document.querySelector('#shipping_state').value = province;
                     lastValid = latlng;
                     if(validInput) validInput.value='1';
                 });
@@ -122,11 +127,15 @@
                 .then(function(data){
                     if(!Array.isArray(data) || !data.length){
                         showError('Address not in delivery area or not found');
+                        document.querySelector('#billing_state').value = '';
+                        document.querySelector('#shipping_state').value = '';
                         return;
                     }
                     var item = data[0];
                     if(!item.address || !item.address.postcode || (allowed.length && allowed.indexOf(item.address.postcode) === -1)){
                         showError('Address not in delivery area or not found');
+                        document.querySelector('#billing_state').value = '';
+                        document.querySelector('#shipping_state').value = '';
                         return;
                     }
                     hideError();


### PR DESCRIPTION
## Summary
- derive province from reverse-geocode data and populate both billing and shipping state fields
- clear state fields when reverse geocode or search fails

## Testing
- `node --check assets/checkout-address.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af9c0cb4208332a2a58b9b169d42a1