### PR TITLE
Remove state from checkout fields

### DIFF
--- a/assets/checkout-address.js
+++ b/assets/checkout-address.js
@@ -88,14 +88,13 @@
                     }
                     hideError();
                     var full = data.display_name || '';
-                    var province = addr.county || addr.state || '';
                     if(resolvedInput) resolvedInput.value = full;
                     document.querySelector('#billing_postcode').value = pc;
                     document.querySelector('#billing_address_1').value = full;
                     document.querySelector('#billing_city').value = addr.city || addr.town || addr.village || '';
                     document.querySelector('#billing_country').value = (addr.country_code || '').toUpperCase();
-                    document.querySelector('#billing_state').value = province;
-                    document.querySelector('#shipping_state').value = province;
+                    document.querySelector('#billing_state').value = '';
+                    document.querySelector('#shipping_state').value = '';
                     lastValid = latlng;
                     if(validInput) validInput.value='1';
                 });

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -906,7 +906,8 @@ final class WCOF_Plugin {
     }
 
     public function hide_billing_fields($fields){
-        $base = ['first_name','last_name','company','address_1','address_2','city','postcode','state','country','phone'];
+        // Hide unused address fields but keep city and postcode visible
+        $base = ['first_name','last_name','company','address_1','address_2','state','country','phone'];
         foreach(['billing','shipping'] as $section){
             foreach($base as $part){
                 $key = $section . '_' . $part;


### PR DESCRIPTION
## Summary
- Keep billing/shipping city and postcode fields visible while hiding other address fields, including state
- Stop autofilling state in checkout address script so province isn't stored

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/checkout-address.js`


------
https://chatgpt.com/codex/tasks/task_e_68af9f6b59ac833293822a44138ed000