### PR TITLE
Show checkout typed address and coordinates on order dashboard

### DIFF
--- a/assets/orders-admin.js
+++ b/assets/orders-admin.js
@@ -55,6 +55,8 @@
     const arrival = o.arrival ? `<span class="wcof-arrival">${htmlEscape(o.arrival)}</span>` : '—';
     const collapsed = o.status==='wc-completed';
     const address = htmlEscape(o.address||'');
+    const typed = htmlEscape(o.address_typed||'');
+    const coords = htmlEscape(o.coords||'');
     const phone = htmlEscape(o.phone||'');
     const note = htmlEscape(o.note||'');
     return `<div class="wcof-card wcof-new" data-id="${htmlEscape(o.id||'')}" data-status="${htmlEscape(o.status||'')}">
@@ -69,7 +71,9 @@
         <div class="wcof-items" style="grid-column:2 / 6;padding:12px 16px;background:#f9fafb;border-top:1px dashed #e5e7eb;${collapsed?'display:none;':''}">
           ${items.map(it=>`<div class="wcof-item"><span>${htmlEscape(it.name)}</span> <strong>× ${it.qty|0}</strong></div>`).join('')}
           <div class="wcof-info">
-            <div><strong>Indirizzo:</strong> ${address}</div>
+            ${address?`<div><strong>Indirizzo mappa:</strong> ${address}</div>`:''}
+            ${typed?`<div><strong>Indirizzo digitato:</strong> ${typed}</div>`:''}
+            ${coords?`<div><strong>Coordinate:</strong> ${coords}</div>`:''}
             <div><strong>Telefono:</strong> ${phone}</div>
             ${note?`<div><strong>Note:</strong> ${note}</div>`:''}
           </div>

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -415,15 +415,21 @@ final class WCOF_Plugin {
                     $arrival=$arrival_ts?date_i18n('H:i',$arrival_ts):null;
                     $items=[]; foreach($o->get_items() as $it){ $items[]=['name'=>$it->get_name(),'qty'=>(int)$it->get_quantity()]; }
                     $total_raw = html_entity_decode( wp_strip_all_tags($o->get_formatted_order_total()), ENT_QUOTES, 'UTF-8' );
-                    $address = trim(implode(', ', array_filter([
-                        $o->get_shipping_address_1(), $o->get_shipping_address_2(),
-                        trim($o->get_shipping_postcode().' '.$o->get_shipping_city())
-                    ])));
+                    $resolved = $o->get_meta('_wcof_delivery_resolved');
+                    $typed    = $o->get_meta('_wcof_delivery_address');
+                    $coords   = $o->get_meta('_wcof_delivery_coords');
+                    $address  = $resolved;
                     if(!$address){
                         $address = trim(implode(', ', array_filter([
-                            $o->get_billing_address_1(), $o->get_billing_address_2(),
-                            trim($o->get_billing_postcode().' '.$o->get_billing_city())
+                            $o->get_shipping_address_1(), $o->get_shipping_address_2(),
+                            trim($o->get_shipping_postcode().' '.$o->get_shipping_city())
                         ])));
+                        if(!$address){
+                            $address = trim(implode(', ', array_filter([
+                                $o->get_billing_address_1(), $o->get_billing_address_2(),
+                                trim($o->get_billing_postcode().' '.$o->get_billing_city())
+                            ])));
+                        }
                     }
                     $phone = $o->get_billing_phone();
                     $note  = $o->get_customer_note();
@@ -440,6 +446,8 @@ final class WCOF_Plugin {
                         'out_url'   =>wp_nonce_url(admin_url('admin-post.php?action=wcof_out_for_delivery&order_id='.$id),'wcof_out_for_delivery_'.$id),
                         'complete_url'=>wp_nonce_url(admin_url('admin-post.php?action=wcof_complete&order_id='.$id),'wcof_complete_'.$id),
                         'address'=>$address,
+                        'address_typed'=>$typed,
+                        'coords'=>$coords,
                         'phone'=>$phone,
                         'note'=>$note,
                     ];


### PR DESCRIPTION
## Summary
- expose typed address and coordinates in orders REST API
- show map address, typed address and coordinates in order dashboard cards

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/orders-admin.js`

------
https://chatgpt.com/codex/tasks/task_e_68b02245f69c8332a468a38ecd8a228f