### PR TITLE
Display order metadata in front-end dashboard

### DIFF
--- a/assets/orders-admin.js
+++ b/assets/orders-admin.js
@@ -59,6 +59,9 @@
     const coords = htmlEscape(o.coords||'');
     const phone = htmlEscape(o.phone||'');
     const note = htmlEscape(o.note||'');
+    const metaHtml = o.meta && typeof o.meta === 'object'
+      ? Object.keys(o.meta).map(k=>`<div><strong>${htmlEscape(k)}:</strong> ${htmlEscape(o.meta[k])}</div>`).join('')
+      : '';
     return `<div class="wcof-card wcof-new" data-id="${htmlEscape(o.id||'')}" data-status="${htmlEscape(o.status||'')}">
       <div class="wcof-head" style="display:grid;grid-template-columns:8px 1fr auto auto auto;gap:14px;align-items:center;padding:16px">
         <div class="wcof-left ${statusBar(o.status||'wc-on-hold')}" style="grid-row:1 / span 3"></div>
@@ -77,6 +80,7 @@
 
             <div><strong>Telefono:</strong> ${phone}</div>
             <div><strong>Note:</strong> ${note || '—'}</div>
+            ${metaHtml}
           </div>
         </div>
         <div class="wcof-actions" style="grid-column:2 / 6">${actionButtons(o)}</div>

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -433,6 +433,19 @@ final class WCOF_Plugin {
                     }
                     $phone = $o->get_billing_phone();
                     $note  = $o->get_customer_note();
+                    $meta  = [];
+                    foreach ( $o->get_meta_data() as $md ) {
+                        $data = $md->get_data();
+                        $k = isset( $data['key'] ) ? $data['key'] : '';
+                        if ( $k === '' ) {
+                            continue;
+                        }
+                        $v = isset( $data['value'] ) ? $data['value'] : '';
+                        if ( is_array( $v ) || is_object( $v ) ) {
+                            $v = wp_json_encode( $v );
+                        }
+                        $meta[ $k ] = (string) $v;
+                    }
                     $out[]=[
                         'id'=>$id,'number'=>$o->get_order_number(),
                         'status'=>'wc-'.$status_slug,'status_name'=>$this->status_name('wc-'.$status_slug),'eta'=>$eta,
@@ -450,6 +463,7 @@ final class WCOF_Plugin {
                         'coords'=>$coords,
                         'phone'=>$phone,
                         'note'=>$note,
+                        'meta'=>$meta,
                     ];
                 }
                 return ['latest_id'=>$latest_id,'orders'=>$out];


### PR DESCRIPTION
## Summary
- expose all WooCommerce order metadata via REST API
- render order meta entries in the orders dashboard cards

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/orders-admin.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68b02e4cc5308332a2edfa78be469b3a