### PR TITLE
Add map and phone actions to order info

### DIFF
--- a/assets/orders-admin.js
+++ b/assets/orders-admin.js
@@ -56,7 +56,6 @@
     const collapsed = o.status==='wc-completed';
     const address = htmlEscape(o.address||'');
     const typed = htmlEscape(o.address_typed||'');
-    const coords = htmlEscape(o.coords||'');
     const phone = htmlEscape(o.phone||'');
     const note = htmlEscape(o.note||'');
     const metaHtml = o.meta && typeof o.meta === 'object'
@@ -74,11 +73,9 @@
         <div class="wcof-items" style="grid-column:2 / 6;padding:12px 16px;background:#f9fafb;border-top:1px dashed #e5e7eb;${collapsed?'display:none;':''}">
           ${items.map(it=>`<div class="wcof-item"><span>${htmlEscape(it.name)}</span> <strong>× ${it.qty|0}</strong></div>`).join('')}
           <div class="wcof-info">
-            <div><strong>Indirizzo mappa:</strong> ${address || '—'}</div>
-            <div><strong>Coordinate:</strong> ${coords || '—'}</div>
-            <div><strong>Indirizzo digitato:</strong> ${typed || '—'}</div>
+            ${typed ? `<div><strong>Indirizzo digitato:</strong> ${typed}${address?`<div class=\"wcof-address-extra\">(${address})</div>`:''}${(o.address_typed||o.coords)?`<div class=\"wcof-map-buttons\">${o.address_typed?`<a class=\"btn btn-map\" target=\"_blank\" href=\"https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(o.address_typed)}\">Mappa indirizzo</a>`:''}${o.coords?` <a class=\"btn btn-map\" target=\"_blank\" href=\"https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(o.coords)}\">Mappa coord</a>`:''}</div>`:''}</div>` : (address?`<div><strong>Indirizzo mappa:</strong> ${address}${o.coords?`<div class=\"wcof-map-buttons\"><a class=\"btn btn-map\" target=\"_blank\" href=\"https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(o.coords)}\">Mappa</a></div>`:''}</div>`:'')}
 
-            <div><strong>Telefono:</strong> ${phone}</div>
+            <div><strong>Telefono:</strong> ${phone} ${o.phone?`<a class=\"btn btn-phone\" href=\"tel:${encodeURIComponent(o.phone)}\" target=\"_blank\">\u260E\ufe0f</a>`:''}</div>
             <div><strong>Note:</strong> ${note || '—'}</div>
             ${metaHtml}
           </div>

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -629,8 +629,12 @@ final class WCOF_Plugin {
           .btn-out{background:#f59e0b} .btn-out:hover{background:#d97706}
           .btn-complete{background:#10b981} .btn-complete:hover{background:#059669}
           .btn-toggle{background:#6b7280} .btn-toggle:hover{background:#4b5563}
+          .btn-map{background:#3b82f6} .btn-map:hover{background:#2563eb}
+          .btn-phone{background:#10b981} .btn-phone:hover{background:#059669}
           .wcof-info{margin-top:8px;font-size:14px;color:#334155}
           .wcof-info div{margin-top:4px}
+          .wcof-address-extra{font-size:12px;color:#64748b;margin-top:2px}
+          .wcof-map-buttons{margin-top:4px;display:flex;gap:4px;flex-wrap:wrap}
           .wcof-item{display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px dashed #ececec}
           .wcof-item:last-child{border-bottom:0}
           .wcof-new{animation:wcofPulse 1s ease-in-out 5;background:#ecfdf5}
@@ -691,16 +695,25 @@ final class WCOF_Plugin {
                 <div class="wcof-item"><span><?php echo esc_html($it->get_name()); ?></span> <strong>× <?php echo (int)$it->get_quantity(); ?></strong></div>
               <?php endforeach; ?>
               <div class="wcof-info">
-                <?php if($address): ?>
-                  <div><strong>Indirizzo mappa:</strong> <?php echo esc_html($address); ?></div>
-                <?php endif; ?>
-                <?php if($coords): ?>
-                  <div><strong>Coordinate:</strong> <?php echo esc_html($coords); ?></div>
-                <?php endif; ?>
                 <?php if($typed): ?>
-                  <div><strong>Indirizzo digitato:</strong> <?php echo esc_html($typed); ?></div>
+                  <div>
+                    <strong>Indirizzo digitato:</strong> <?php echo esc_html($typed); ?>
+                    <?php if($address): ?><div class="wcof-address-extra">(<?php echo esc_html($address); ?>)</div><?php endif; ?>
+                    <div class="wcof-map-buttons">
+                      <a class="btn btn-map" target="_blank" href="https://www.google.com/maps/search/?api=1&query=<?php echo esc_attr(rawurlencode($typed)); ?>">Mappa indirizzo</a>
+                      <?php if($coords): ?><a class="btn btn-map" target="_blank" href="https://www.google.com/maps/search/?api=1&query=<?php echo esc_attr(rawurlencode($coords)); ?>">Mappa coord</a><?php endif; ?>
+                    </div>
+                  </div>
+                <?php elseif($address): ?>
+                  <div>
+                    <strong>Indirizzo mappa:</strong> <?php echo esc_html($address); ?>
+                    <div class="wcof-map-buttons">
+                      <a class="btn btn-map" target="_blank" href="https://www.google.com/maps/search/?api=1&query=<?php echo esc_attr(rawurlencode($address)); ?>">Mappa indirizzo</a>
+                      <?php if($coords): ?><a class="btn btn-map" target="_blank" href="https://www.google.com/maps/search/?api=1&query=<?php echo esc_attr(rawurlencode($coords)); ?>">Mappa coord</a><?php endif; ?>
+                    </div>
+                  </div>
                 <?php endif; ?>
-                <div><strong>Telefono:</strong> <?php echo esc_html($phone); ?></div>
+                <div><strong>Telefono:</strong> <?php echo esc_html($phone); ?><?php if($phone): ?> <a class="btn btn-phone" target="_blank" href="tel:<?php echo esc_attr(preg_replace('/[^0-9+]/', '', $phone)); ?>">📞</a><?php endif; ?></div>
                 <?php if($note): ?><div><strong>Note:</strong> <?php echo esc_html($note); ?></div><?php endif; ?>
               </div>
               </div>


### PR DESCRIPTION
## Summary
- show typed address with resolved address in parentheses
- link address and coordinates to Google Maps
- add click-to-call phone button

## Testing
- `node --check assets/orders-admin.js`
- `php -l wc-order-flow.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0596eff4c8332a58f69bf04f909da