### PR TITLE
Validate delivery address flag before checkout

### DIFF
--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -1015,7 +1015,10 @@ final class WCOF_Plugin {
         $address  = isset($_POST['wcof_delivery_address']) ? sanitize_text_field($_POST['wcof_delivery_address']) : '';
         $valid    = isset($_POST['wcof_delivery_valid']) ? sanitize_text_field($_POST['wcof_delivery_valid']) : '';
         $coords   = isset($_POST['wcof_delivery_coords']) ? sanitize_text_field($_POST['wcof_delivery_coords']) : '';
-        if($address===''){
+        if($valid !== '1'){
+            wc_add_notice(__('Please confirm a valid address before paying.','wc-order-flow'), 'error');
+            return;
+        }elseif($address===''){
             wc_add_notice(__('Please enter a delivery address.','wc-order-flow'), 'error');
         }elseif($coords===''){
             wc_add_notice(__('Please select a valid address from the map.','wc-order-flow'), 'error');


### PR DESCRIPTION
## Summary
- Ensure `wcof_delivery_valid` flag must equal `1` before checkout proceeds
- Show an error message if delivery address isn't confirmed

## Testing
- `php -l wc-order-flow.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0bb39769c8332b2c8bacbc779b3db