### PR TITLE
Add Stripe checkout styling

### DIFF
--- a/assets/stripe-checkout.css
+++ b/assets/stripe-checkout.css
@@ -1,0 +1,85 @@
+:root {
+  --accent: #635bff;
+  --background: #f5f7fa;
+  --card-bg: #ffffff;
+  --text-color: #2e2e2e;
+  --radius: 12px;
+  --transition: 0.2s ease;
+}
+
+body {
+  background: var(--background);
+  font-family: 'Inter', system-ui, sans-serif;
+  color: var(--text-color);
+  margin: 0;
+  padding: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+#payment-form {
+  width: 360px;
+  background: var(--card-bg);
+  padding: 2rem;
+  border-radius: var(--radius);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.06);
+}
+
+.form-title {
+  margin: 0 0 1rem;
+  text-align: center;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.card-container {
+  border: 1px solid #e0e5ec;
+  border-radius: var(--radius);
+  padding: 12px 14px;
+  margin-bottom: 1.25rem;
+  background: #fafbfc;
+}
+
+#card-element {
+  width: 100%;
+}
+
+button#submit {
+  width: 100%;
+  padding: 0.85rem;
+  background: var(--accent);
+  color: #ffffff;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+button#submit:hover,
+button#submit:focus {
+  background: #5046e5;
+}
+
+button#submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button-text {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#error-message {
+  margin-top: 0.75rem;
+  color: #d64545;
+  text-align: center;
+  min-height: 1em;
+  font-size: 0.9rem;
+}

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -941,6 +941,7 @@ final class WCOF_Plugin {
         $codes = $this->delivery_postal_codes();
         wp_enqueue_style('leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css', [], '1.9.4');
         wp_enqueue_script('leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', [], '1.9.4', true);
+        wp_enqueue_style('wcof-stripe-checkout', plugins_url('assets/stripe-checkout.css', __FILE__), [], '1.0');
         wp_enqueue_script('wcof-checkout-address', plugins_url('assets/checkout-address.js', __FILE__), ['leaflet'], '1.0', true);
         wp_localize_script('wcof-checkout-address', 'wcofCheckoutAddress', [
             'postalCodes' => $codes,


### PR DESCRIPTION
## Summary
- enqueue modern Stripe checkout stylesheet
- add modern CSS for Stripe Elements checkout

## Testing
- `php -l wc-order-flow.php`


------
https://chatgpt.com/codex/tasks/task_e_68b18878e5f08332a18d358512315642