### PR TITLE
Style checkout fields

### DIFF
--- a/assets/checkout.css
+++ b/assets/checkout.css
@@ -1,0 +1,49 @@
+/* Checkout and payment field enhancements */
+.woocommerce-checkout input[type="text"],
+.woocommerce-checkout input[type="tel"],
+.woocommerce-checkout input[type="email"],
+.woocommerce-checkout input[type="password"],
+.woocommerce-checkout textarea,
+.woocommerce-checkout select {
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 12px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: border-color .2s, box-shadow .2s;
+}
+
+.woocommerce-checkout input[type="text"]:focus,
+.woocommerce-checkout input[type="tel"]:focus,
+.woocommerce-checkout input[type="email"]:focus,
+.woocommerce-checkout input[type="password"]:focus,
+.woocommerce-checkout textarea:focus,
+.woocommerce-checkout select:focus {
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 3px rgba(79,70,229,0.15);
+  outline: none;
+}
+
+/* Payment box */
+#payment .payment_box {
+  background: #fff;
+  border: none;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  padding: 20px;
+}
+
+/* Credit card fields */
+.wc-credit-card-wrapper {
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  padding: 10px;
+}
+
+.wc-credit-card-wrapper:focus-within {
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 3px rgba(79,70,229,0.15);
+}
+

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -940,6 +940,7 @@ final class WCOF_Plugin {
         if( !function_exists('is_checkout') || !is_checkout() ) return;
         $codes = $this->delivery_postal_codes();
         wp_enqueue_style('leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css', [], '1.9.4');
+        wp_enqueue_style('wcof-checkout', plugins_url('assets/checkout.css', __FILE__), [], '1.0');
         wp_enqueue_script('leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', [], '1.9.4', true);
         wp_enqueue_script('wcof-checkout-address', plugins_url('assets/checkout-address.js', __FILE__), ['leaflet'], '1.0', true);
         wp_localize_script('wcof-checkout-address', 'wcofCheckoutAddress', [


### PR DESCRIPTION
## Summary
- add CSS for modern checkout and payment fields
- load new checkout stylesheet on checkout pages

## Testing
- `php -l wc-order-flow.php`


------
https://chatgpt.com/codex/tasks/task_e_68b82a3d5f348332846943f525a8867a