### PR TITLE
Autoload last used address in checkout

### DIFF
--- a/assets/checkout-address.js
+++ b/assets/checkout-address.js
@@ -268,6 +268,11 @@
                     if(parts.length === 2){ placeMarker(parts[0], parts[1]); }
                 }
             });
+
+            // Automatically load the most recent address on first render
+            if(addressSelect.options.length && (!validInput || !validInput.value)){
+                addressSelect.dispatchEvent(new Event('change'));
+            }
         }
 
         if(coordInput && coordInput.value){


### PR DESCRIPTION
## Summary
- Preselect the most recent saved address on checkout load
- Populate form fields and map from the selected address automatically

## Testing
- `node --check assets/checkout-address.js`
- `php -l wc-order-flow.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2e93ff0008332be26da54a18c92fd