### PR TITLE
fix: update address selection and marker

### DIFF
--- a/assets/checkout-address.js
+++ b/assets/checkout-address.js
@@ -257,8 +257,8 @@
                 if(!opt) return;
                 var town = opt.getAttribute('data-town') || '';
                 var address = opt.getAttribute('data-address') || '';
-                townInput.value = town;
-                addrInput.value = address;
+                townInput.value = town; townInput.setAttribute('value', town);
+                addrInput.value = address; addrInput.setAttribute('value', address);
                 if(resolvedInput) resolvedInput.value = opt.getAttribute('data-resolved') || '';
                 if(coordInput) coordInput.value = opt.getAttribute('data-coords') || '';
                 var r = opt.getAttribute('data-resolved') || '';
@@ -268,6 +268,7 @@
                     else { summaryEl.textContent=''; summaryEl.style.display='none'; }
                 }
                 if(c){
+                    suppressSearch = true;
                     var parts = c.split(',');
                     if(parts.length === 2){
                         var promise = placeMarker(parts[0], parts[1]);
@@ -277,7 +278,9 @@
                             addrInput.value = address;
                         }
                     }
-                    suppressSearch = true;
+                }else{
+                    // No stored coordinates: resolve via search
+                    searchAddress();
                 }
                 // Ensure WooCommerce and other listeners react to the new values
                 townInput.dispatchEvent(new Event('change', { bubbles: true }));
@@ -286,7 +289,7 @@
             });
 
             // Automatically load the most recent address on first render
-            if(addressSelect.options.length && (!validInput || !validInput.value)){
+            if(addressSelect.options.length){
                 addressSelect.dispatchEvent(new Event('change'));
             }
         }
@@ -304,6 +307,9 @@
                     summaryEl.style.display = 'block';
                 }
             }
+        }else if(townInput.value && addrInput.value){
+            // Coordinates not yet known but we have text fields
+            searchAddress();
         }
 
         var heading=document.querySelector('.woocommerce-billing-fields > h3');


### PR DESCRIPTION
## Summary
- ensure selecting a saved address fills town/address fields and updates map
- auto-load saved address marker or resolve address on page load

## Testing
- `node --check assets/checkout-address.js`
- `php -l wc-order-flow.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f9f0213483329f7c66c6f15f4f99