### PR TITLE
Ensure plugin settings strings are translatable

### DIFF
--- a/languages/wc-order-flow-es_ES.po
+++ b/languages/wc-order-flow-es_ES.po
@@ -194,3 +194,108 @@ msgstr "Aprobado"
 
 msgid "Rider on the way"
 msgstr "Repartidor en camino"
+
+msgid "Rider"
+msgstr "Repartidor"
+
+msgid "Delivery completed."
+msgstr "Entrega completada."
+
+msgid "Store settings"
+msgstr "Configuración de la tienda"
+
+msgid "Address"
+msgstr "Dirección"
+
+msgid "Delivery postal codes"
+msgstr "Códigos postales de entrega"
+
+msgid "e.g. 00100,00101"
+msgstr "p. ej. 00100,00101"
+
+msgid "Mon"
+msgstr "Lun"
+
+msgid "Tue"
+msgstr "Mar"
+
+msgid "Wed"
+msgstr "Mié"
+
+msgid "Thu"
+msgstr "Jue"
+
+msgid "Fri"
+msgstr "Vie"
+
+msgid "Sat"
+msgstr "Sáb"
+
+msgid "Sun"
+msgstr "Dom"
+
+msgid "OneSignal"
+msgstr "OneSignal"
+
+msgid "Store"
+msgstr "Tienda"
+
+msgid "Save settings"
+msgstr "Guardar ajustes"
+
+msgid "Add rider"
+msgstr "Añadir repartidor"
+
+msgid "Username"
+msgstr "Nombre de usuario"
+
+msgid "Email"
+msgstr "Correo electrónico"
+
+msgid "Password"
+msgstr "Contraseña"
+
+msgid "ReeservaFood Settings"
+msgstr "Configuración de ReeservaFood"
+
+msgid "Service worker files are auto-served at %1$s and %2$s via WordPress rewrites (no physical files needed)."
+msgstr "Los archivos del service worker se sirven automáticamente en %1$s y %2$s mediante las reescrituras de WordPress (no se necesitan archivos físicos)."
+
+msgid "Shortcodes"
+msgstr "Shortcodes"
+
+msgid "orders board"
+msgstr "panel de pedidos"
+
+msgid "product manager"
+msgstr "gestor de productos"
+
+msgid "subscribe button"
+msgstr "botón de suscripción"
+
+msgid "admin diagnostics"
+msgstr "diagnóstico de administrador"
+
+msgid "Please complete the <a href=\"%s\">ReeservaFood setup</a>."
+msgstr "Completa la <a href=\"%s\">configuración de ReeservaFood</a>."
+
+msgid "Welcome to ReeservaFood"
+msgstr "Bienvenido a ReeservaFood"
+
+msgid "Let's configure your store."
+msgstr "Configuremos tu tienda."
+
+msgid "Shop address"
+msgstr "Dirección de la tienda"
+
+msgid "Products"
+msgstr "Productos"
+
+msgid "Manage products"
+msgstr "Gestionar productos"
+
+msgid "Start Selling now"
+msgstr "Comenzar a vender ahora"
+
+msgid "Keep the store closed for now"
+msgstr "Mantener la tienda cerrada por ahora"

--- a/languages/wc-order-flow-it_IT.po
+++ b/languages/wc-order-flow-it_IT.po
@@ -194,3 +194,108 @@ msgstr "Approvato"
 
 msgid "Rider on the way"
 msgstr "Rider in arrivo"
+
+msgid "Rider"
+msgstr "Rider"
+
+msgid "Delivery completed."
+msgstr "Consegna completata."
+
+msgid "Store settings"
+msgstr "Impostazioni negozio"
+
+msgid "Address"
+msgstr "Indirizzo"
+
+msgid "Delivery postal codes"
+msgstr "CAP di consegna"
+
+msgid "e.g. 00100,00101"
+msgstr "es. 00100,00101"
+
+msgid "Mon"
+msgstr "Lun"
+
+msgid "Tue"
+msgstr "Mar"
+
+msgid "Wed"
+msgstr "Mer"
+
+msgid "Thu"
+msgstr "Gio"
+
+msgid "Fri"
+msgstr "Ven"
+
+msgid "Sat"
+msgstr "Sab"
+
+msgid "Sun"
+msgstr "Dom"
+
+msgid "OneSignal"
+msgstr "OneSignal"
+
+msgid "Store"
+msgstr "Negozio"
+
+msgid "Save settings"
+msgstr "Salva impostazioni"
+
+msgid "Add rider"
+msgstr "Aggiungi rider"
+
+msgid "Username"
+msgstr "Nome utente"
+
+msgid "Email"
+msgstr "Email"
+
+msgid "Password"
+msgstr "Password"
+
+msgid "ReeservaFood Settings"
+msgstr "Impostazioni ReeservaFood"
+
+msgid "Service worker files are auto-served at %1$s and %2$s via WordPress rewrites (no physical files needed)."
+msgstr "I file del service worker sono serviti automaticamente su %1$s e %2$s tramite le riscritture di WordPress (nessun file fisico necessario)."
+
+msgid "Shortcodes"
+msgstr "Shortcode"
+
+msgid "orders board"
+msgstr "bacheca ordini"
+
+msgid "product manager"
+msgstr "gestore prodotti"
+
+msgid "subscribe button"
+msgstr "pulsante di iscrizione"
+
+msgid "admin diagnostics"
+msgstr "diagnostica admin"
+
+msgid "Please complete the <a href=\"%s\">ReeservaFood setup</a>."
+msgstr "Completa la <a href=\"%s\">configurazione di ReeservaFood</a>."
+
+msgid "Welcome to ReeservaFood"
+msgstr "Benvenuto su ReeservaFood"
+
+msgid "Let's configure your store."
+msgstr "Configuriamo il tuo negozio."
+
+msgid "Shop address"
+msgstr "Indirizzo del negozio"
+
+msgid "Products"
+msgstr "Prodotti"
+
+msgid "Manage products"
+msgstr "Gestisci prodotti"
+
+msgid "Start Selling now"
+msgstr "Inizia a vendere ora"
+
+msgid "Keep the store closed for now"
+msgstr "Mantieni il negozio chiuso per ora"

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -25,7 +25,7 @@ final class WCOF_Plugin {
         $self = new self();
         $self->register_sw_rewrite();
         if( !get_option('wcof_setup_done') ) add_option('wcof_setup_done', 0);
-        add_role('rider', 'Rider', ['read'=>true,'wcof_rider'=>true]);
+        add_role('rider', __('Rider', 'wc-order-flow'), ['read'=>true,'wcof_rider'=>true]);
         flush_rewrite_rules();
 
         // Switch checkout page to classic shortcode
@@ -430,7 +430,7 @@ final class WCOF_Plugin {
                 $set=$this->settings();
                 if(empty($set['rider_see_processing']) && $o->has_status('processing')) wp_die(__('Unauthorized', 'wc-order-flow'));
             }
-            $o->update_status('completed','Consegna completata.');
+            $o->update_status('completed', __('Delivery completed.', 'wc-order-flow'));
             $o->save();
         }
         wp_safe_redirect(wp_get_referer()?wp_get_referer():admin_url('post.php?post='.$order_id.'&action=edit')); exit;
@@ -891,26 +891,26 @@ final class WCOF_Plugin {
           <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="margin-bottom:24px">
             <?php wp_nonce_field('wcof_save_store'); ?>
             <input type="hidden" name="action" value="wcof_save_store"/>
-            <h2>Store settings</h2>
-            <p><label>Address<br/><input type="text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[address]" value="<?php echo esc_attr($s['address']); ?>"/></label></p>
-            <p>Opening days:<br/>
-              <?php foreach(['mon'=>'Mon','tue'=>'Tue','wed'=>'Wed','thu'=>'Thu','fri'=>'Fri','sat'=>'Sat','sun'=>'Sun'] as $k=>$lbl): ?>
+            <h2><?php esc_html_e('Store settings', 'wc-order-flow'); ?></h2>
+            <p><label><?php esc_html_e('Address', 'wc-order-flow'); ?><br/><input type="text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[address]" value="<?php echo esc_attr($s['address']); ?>"/></label></p>
+            <p><?php esc_html_e('Opening days', 'wc-order-flow'); ?>:<br/>
+              <?php foreach(['mon'=>__('Mon','wc-order-flow'),'tue'=>__('Tue','wc-order-flow'),'wed'=>__('Wed','wc-order-flow'),'thu'=>__('Thu','wc-order-flow'),'fri'=>__('Fri','wc-order-flow'),'sat'=>__('Sat','wc-order-flow'),'sun'=>__('Sun','wc-order-flow')] as $k=>$lbl): ?>
                 <label style="margin-right:8px"><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[open_days][]" value="<?php echo esc_attr($k); ?>" <?php checked(in_array($k,$s['open_days'],true)); ?>/> <?php echo esc_html($lbl); ?></label>
               <?php endforeach; ?>
             </p>
-            <p><label>Opening time <input type="time" name="<?php echo esc_attr(self::OPTION_KEY); ?>[open_time]" value="<?php echo esc_attr($s['open_time']); ?>"/> – <input type="time" name="<?php echo esc_attr(self::OPTION_KEY); ?>[close_time]" value="<?php echo esc_attr($s['close_time']); ?>"/></label></p>
-            <p><label><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[store_closed]" value="1" <?php checked($s['store_closed'],1); ?>/> Store closed</label></p>
-            <p><label><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[rider_see_processing]" value="1" <?php checked($s['rider_see_processing'],1); ?>/> Riders can see processing</label></p>
-            <p><button type="submit">Save settings</button></p>
+            <p><label><?php esc_html_e('Opening time', 'wc-order-flow'); ?> <input type="time" name="<?php echo esc_attr(self::OPTION_KEY); ?>[open_time]" value="<?php echo esc_attr($s['open_time']); ?>"/> – <input type="time" name="<?php echo esc_attr(self::OPTION_KEY); ?>[close_time]" value="<?php echo esc_attr($s['close_time']); ?>"/></label></p>
+            <p><label><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[store_closed]" value="1" <?php checked($s['store_closed'],1); ?>/> <?php esc_html_e('Store closed', 'wc-order-flow'); ?></label></p>
+            <p><label><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[rider_see_processing]" value="1" <?php checked($s['rider_see_processing'],1); ?>/> <?php esc_html_e('Riders see processing', 'wc-order-flow'); ?></label></p>
+            <p><button type="submit"><?php esc_html_e('Save settings', 'wc-order-flow'); ?></button></p>
           </form>
           <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
             <?php wp_nonce_field('wcof_add_rider'); ?>
             <input type="hidden" name="action" value="wcof_add_rider"/>
-            <h2>Add rider</h2>
-            <p><input type="text" name="rider_user" placeholder="Username" required/></p>
-            <p><input type="email" name="rider_email" placeholder="Email" required/></p>
-            <p><input type="password" name="rider_pass" placeholder="Password" required/></p>
-            <p><button type="submit">Add rider</button></p>
+            <h2><?php esc_html_e('Add rider', 'wc-order-flow'); ?></h2>
+            <p><input type="text" name="rider_user" placeholder="<?php esc_attr_e('Username', 'wc-order-flow'); ?>" required/></p>
+            <p><input type="email" name="rider_email" placeholder="<?php esc_attr_e('Email', 'wc-order-flow'); ?>" required/></p>
+            <p><input type="password" name="rider_pass" placeholder="<?php esc_attr_e('Password', 'wc-order-flow'); ?>" required/></p>
+            <p><button type="submit"><?php esc_html_e('Add rider', 'wc-order-flow'); ?></button></p>
           </form>
         </div>
         <?php return ob_get_clean();
@@ -1306,13 +1306,13 @@ final class WCOF_Plugin {
     public function settings_page(){
         $s=$this->settings(); ?>
         <div class="wrap">
-          <h1>ReeservaFood Settings</h1>
+          <h1><?php esc_html_e('ReeservaFood Settings', 'wc-order-flow'); ?></h1>
           <form method="post" action="options.php">
             <?php settings_fields(self::OPTION_KEY); ?>
-            <h2>Store</h2>
+            <h2><?php esc_html_e('Store', 'wc-order-flow'); ?></h2>
             <table class="form-table" role="presentation">
-              <tr><th scope="row">Address</th><td><input type="text" class="regular-text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[address]" value="<?php echo esc_attr($s['address']); ?>"/></td></tr>
-              <tr><th scope="row">Delivery postal codes</th><td><input type="text" class="regular-text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[postal_codes]" value="<?php echo esc_attr($s['postal_codes']); ?>" placeholder="e.g. 00100,00101"/></td></tr>
+              <tr><th scope="row"><?php esc_html_e('Address', 'wc-order-flow'); ?></th><td><input type="text" class="regular-text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[address]" value="<?php echo esc_attr($s['address']); ?>"/></td></tr>
+              <tr><th scope="row"><?php esc_html_e('Delivery postal codes', 'wc-order-flow'); ?></th><td><input type="text" class="regular-text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[postal_codes]" value="<?php echo esc_attr($s['postal_codes']); ?>" placeholder="<?php esc_attr_e('e.g. 00100,00101', 'wc-order-flow'); ?>"/></td></tr>
               <tr><th scope="row"><?php esc_html_e('Language', 'wc-order-flow'); ?></th><td>
                 <select name="<?php echo esc_attr(self::OPTION_KEY); ?>[language]">
                   <option value="auto" <?php selected($s['language'],'auto'); ?>><?php esc_html_e('Automatic', 'wc-order-flow'); ?></option>
@@ -1322,7 +1322,7 @@ final class WCOF_Plugin {
                 </select>
               </td></tr>
               <tr><th scope="row"><?php esc_html_e('Opening days', 'wc-order-flow'); ?></th><td>
-                <?php foreach(['mon'=>'Mon','tue'=>'Tue','wed'=>'Wed','thu'=>'Thu','fri'=>'Fri','sat'=>'Sat','sun'=>'Sun'] as $k=>$lbl): ?>
+                <?php foreach(['mon'=>__('Mon','wc-order-flow'),'tue'=>__('Tue','wc-order-flow'),'wed'=>__('Wed','wc-order-flow'),'thu'=>__('Thu','wc-order-flow'),'fri'=>__('Fri','wc-order-flow'),'sat'=>__('Sat','wc-order-flow'),'sun'=>__('Sun','wc-order-flow')] as $k=>$lbl): ?>
                   <label style="margin-right:8px"><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[open_days][]" value="<?php echo esc_attr($k); ?>" <?php checked(in_array($k,$s['open_days'],true)); ?>/> <?php echo esc_html($lbl); ?></label>
                 <?php endforeach; ?>
               </td></tr>
@@ -1330,13 +1330,13 @@ final class WCOF_Plugin {
               <tr><th scope="row"><?php esc_html_e('Store closed', 'wc-order-flow'); ?></th><td><label><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[store_closed]" value="1" <?php checked($s['store_closed'],1); ?>/> <?php esc_html_e('Yes', 'wc-order-flow'); ?></label></td></tr>
               <tr><th scope="row"><?php esc_html_e('Riders see processing', 'wc-order-flow'); ?></th><td><label><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[rider_see_processing]" value="1" <?php checked($s['rider_see_processing'],1); ?>/> <?php esc_html_e('Yes', 'wc-order-flow'); ?></label></td></tr>
             </table>
-            <h2>OneSignal</h2>
+            <h2><?php esc_html_e('OneSignal', 'wc-order-flow'); ?></h2>
             <table class="form-table" role="presentation">
               <tr><th scope="row"><?php esc_html_e('Enable push', 'wc-order-flow'); ?></th><td><label><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[enable]" value="1" <?php checked($s['enable'],1); ?>/> <?php esc_html_e('On', 'wc-order-flow'); ?></label></td></tr>
               <tr><th scope="row"><?php esc_html_e('OneSignal App ID', 'wc-order-flow'); ?></th><td><input type="text" class="regular-text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[app_id]" value="<?php echo esc_attr($s['app_id']); ?>" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"/></td></tr>
               <tr><th scope="row"><?php esc_html_e('OneSignal REST API Key', 'wc-order-flow'); ?></th><td><input type="text" class="regular-text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[rest_key]" value="<?php echo esc_attr($s['rest_key']); ?>" placeholder="REST API Key (server)"/></td></tr>
             </table>
-            <h2>Notify on</h2>
+            <h2><?php esc_html_e('Notify on', 'wc-order-flow'); ?></h2>
             <table class="form-table" role="presentation">
               <tr><th><?php esc_html_e('Admin', 'wc-order-flow'); ?></th><td><label><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[notify_admin_new]" value="1" <?php checked($s['notify_admin_new'],1); ?>/> <?php esc_html_e('New order', 'wc-order-flow'); ?></label></td></tr>
               <tr><th><?php esc_html_e('User', 'wc-order-flow'); ?></th><td>
@@ -1346,8 +1346,27 @@ final class WCOF_Plugin {
             </table>
             <?php submit_button(); ?>
           </form>
-          <p><em>Service worker files are auto-served at <code>/OneSignalSDKWorker.js</code> and <code>/OneSignalSDKUpdaterWorker.js</code> via WordPress rewrites (no physical files needed).</em></p>
-          <p><strong>Shortcodes</strong>: <code>[wcof_orders_admin]</code> (orders board), <code>[wcof_product_manager]</code> (product manager), <code>[wcof_push_button]</code> (subscribe button), <code>[wcof_push_debug]</code> (admin diagnostics).</p>
+          <?php
+            printf(
+              '<p><em>%s</em></p>',
+              sprintf(
+                wp_kses(
+                  __('Service worker files are auto-served at %1$s and %2$s via WordPress rewrites (no physical files needed).', 'wc-order-flow'),
+                  ['code'=>[]]
+                ),
+                '<code>/OneSignalSDKWorker.js</code>',
+                '<code>/OneSignalSDKUpdaterWorker.js</code>'
+              )
+            );
+            printf(
+              '<p><strong>%s</strong>: <code>[wcof_orders_admin]</code> (%s), <code>[wcof_product_manager]</code> (%s), <code>[wcof_push_button]</code> (%s), <code>[wcof_push_debug]</code> (%s).</p>',
+              esc_html__('Shortcodes', 'wc-order-flow'),
+              esc_html__('orders board', 'wc-order-flow'),
+              esc_html__('product manager', 'wc-order-flow'),
+              esc_html__('subscribe button', 'wc-order-flow'),
+              esc_html__('admin diagnostics', 'wc-order-flow')
+            );
+          ?>
         </div>
         <?php
     }
@@ -1365,30 +1384,36 @@ final class WCOF_Plugin {
     public function setup_notice(){
         $url = esc_url(admin_url('admin.php?page=wcof-setup'));
         echo '<div class="notice notice-warning"><p>';
-        echo 'Please complete the <a href="'.$url.'">ReeservaFood setup</a>.';
+        printf(
+            wp_kses(
+                __('Please complete the <a href="%s">ReeservaFood setup</a>.', 'wc-order-flow'),
+                ['a' => ['href' => []]]
+            ),
+            $url
+        );
         echo '</p></div>';
     }
 
     public function setup_page(){
         $s=$this->settings(); ?>
         <div class="wrap">
-          <h1>Welcome to ReeservaFood</h1>
-          <p>Let's configure your store.</p>
+          <h1><?php esc_html_e('Welcome to ReeservaFood', 'wc-order-flow'); ?></h1>
+          <p><?php esc_html_e("Let's configure your store.", 'wc-order-flow'); ?></p>
           <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
             <?php wp_nonce_field('wcof_finish_setup'); ?>
             <input type="hidden" name="action" value="wcof_finish_setup"/>
             <table class="form-table" role="presentation">
-              <tr><th scope="row">Shop address</th><td><input type="text" class="regular-text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[address]" value="<?php echo esc_attr($s['address']); ?>"/></td></tr>
-              <tr><th scope="row">Opening days</th><td>
-                <?php foreach(['mon'=>'Mon','tue'=>'Tue','wed'=>'Wed','thu'=>'Thu','fri'=>'Fri','sat'=>'Sat','sun'=>'Sun'] as $k=>$lbl): ?>
+              <tr><th scope="row"><?php esc_html_e('Shop address', 'wc-order-flow'); ?></th><td><input type="text" class="regular-text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[address]" value="<?php echo esc_attr($s['address']); ?>"/></td></tr>
+              <tr><th scope="row"><?php esc_html_e('Opening days', 'wc-order-flow'); ?></th><td>
+                <?php foreach(['mon'=>__('Mon','wc-order-flow'),'tue'=>__('Tue','wc-order-flow'),'wed'=>__('Wed','wc-order-flow'),'thu'=>__('Thu','wc-order-flow'),'fri'=>__('Fri','wc-order-flow'),'sat'=>__('Sat','wc-order-flow'),'sun'=>__('Sun','wc-order-flow')] as $k=>$lbl): ?>
                   <label style="margin-right:8px"><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[open_days][]" value="<?php echo esc_attr($k); ?>" <?php checked(in_array($k,$s['open_days'],true)); ?>/> <?php echo esc_html($lbl); ?></label>
                 <?php endforeach; ?>
               </td></tr>
-              <tr><th scope="row">Opening time</th><td><input type="time" name="<?php echo esc_attr(self::OPTION_KEY); ?>[open_time]" value="<?php echo esc_attr($s['open_time']); ?>"/> – <input type="time" name="<?php echo esc_attr(self::OPTION_KEY); ?>[close_time]" value="<?php echo esc_attr($s['close_time']); ?>"/></td></tr>
-              <tr><th scope="row">Products</th><td><a href="<?php echo esc_url(admin_url('edit.php?post_type=product')); ?>" class="button">Manage products</a></td></tr>
+              <tr><th scope="row"><?php esc_html_e('Opening time', 'wc-order-flow'); ?></th><td><input type="time" name="<?php echo esc_attr(self::OPTION_KEY); ?>[open_time]" value="<?php echo esc_attr($s['open_time']); ?>"/> – <input type="time" name="<?php echo esc_attr(self::OPTION_KEY); ?>[close_time]" value="<?php echo esc_attr($s['close_time']); ?>"/></td></tr>
+              <tr><th scope="row"><?php esc_html_e('Products', 'wc-order-flow'); ?></th><td><a href="<?php echo esc_url(admin_url('edit.php?post_type=product')); ?>" class="button"><?php esc_html_e('Manage products', 'wc-order-flow'); ?></a></td></tr>
             </table>
-            <?php submit_button('Start Selling now','primary','start'); ?>
-            <?php submit_button('Keep the store closed for now','secondary','keep'); ?>
+            <?php submit_button(__('Start Selling now', 'wc-order-flow'),'primary','start'); ?>
+            <?php submit_button(__('Keep the store closed for now', 'wc-order-flow'),'secondary','keep'); ?>
           </form>
         </div>
         <?php


### PR DESCRIPTION
## Summary
- Internationalize plugin and setup settings so all labels respect the chosen language
- Add Italian and Spanish translations for new strings such as days of the week, address fields and setup instructions

## Testing
- `php -l wc-order-flow.php`
- `msgfmt --check -o /tmp/it.mo languages/wc-order-flow-it_IT.po`
- `msgfmt --check -o /tmp/es.mo languages/wc-order-flow-es_ES.po`


------
https://chatgpt.com/codex/tasks/task_e_68c4986bf31083329bf099fe9fff7c98