### PR TITLE
Link push notifications to customers

### DIFF
--- a/assets/push-button.js
+++ b/assets/push-button.js
@@ -2,29 +2,47 @@
   function el(id){ return document.getElementById(id); }
   const btn = el('wcof-push-btn');
   const status = el('wcof-push-status');
-  function setStatus(t){ if(status) status.textContent = t; }
+  const isAdmin = window.WCOF_PUSH && WCOF_PUSH.isAdmin;
+  const enableLabel  = isAdmin ? '🔔 Enable admin notifications' : '🔔 Enable notifications';
+  const disableLabel = isAdmin ? '🔕 Disable admin notifications' : '🔕 Disable notifications';
+
+  function updateUI(enabled){
+    if(status){
+      status.textContent = enabled
+        ? (isAdmin ? 'Admin subscribed' : 'Subscribed')
+        : (isAdmin ? 'Admin not subscribed' : 'Not subscribed');
+    }
+    if(btn) btn.textContent = enabled ? disableLabel : enableLabel;
+  }
+
   function refresh(){
     if(!window.OneSignal){ setTimeout(refresh, 400); return; }
     OneSignal.push(function(){
       OneSignal.isPushNotificationsEnabled(function(enabled){
-        setStatus(enabled ? 'Subscribed' : 'Not subscribed');
-        if(btn) btn.textContent = enabled ? '🔕 Disable notifications' : '🔔 Enable notifications';
+        updateUI(enabled);
       });
     });
   }
+
   if(btn){
     btn.addEventListener('click', function(){
       if(!window.OneSignal) return;
       OneSignal.push(function(){
         OneSignal.isPushNotificationsEnabled(function(enabled){
           if(enabled){
-            OneSignal.setSubscription(false); setTimeout(refresh, 800);
+            OneSignal.setSubscription(false);
+            setTimeout(refresh, 800);
           } else {
-            OneSignal.showSlidedownPrompt(); setTimeout(refresh, 1200);
+            if(window.WCOF_PUSH && WCOF_PUSH.userId){
+              OneSignal.setExternalUserId(String(WCOF_PUSH.userId));
+            }
+            OneSignal.showSlidedownPrompt();
+            setTimeout(refresh, 1200);
           }
         });
       });
     });
   }
+
   setTimeout(refresh, 800);
 })();

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -132,6 +132,9 @@ final class WCOF_Plugin {
         // Push shortcodes (button + debug)
         add_shortcode('wcof_push_button', [$this,'shortcode_push_button']);
         add_shortcode('wcof_push_debug',  [$this,'shortcode_push_debug']);
+
+        // Display opt-in button on customer account pages
+        add_action('woocommerce_account_dashboard', [$this,'account_push_button']);
     }
 
     /* ===== Service workers via rewrite to site root ===== */
@@ -1456,6 +1459,8 @@ final class WCOF_Plugin {
             'headings'=>['en'=>$title,'es'=>$title,'it'=>$title],
             'contents'=>['en'=>'ETA ~ '.$eta.' min','es'=>'ETA ~ '.$eta.' min','it'=>'ETA ~ '.$eta.' min'],
             'url'=>$url,
+            // Target the purchasing user via external ID and role tag
+            'filters' => [ [ 'field'=>'tag','key'=>'wcof_role','relation'=>'=','value'=>'user' ] ],
             'include_external_user_ids' => [ (string)$uid ],
             'ttl'=>300
         ]);
@@ -1469,6 +1474,7 @@ final class WCOF_Plugin {
             'headings'=>['en'=>$title,'es'=>$title,'it'=>$title],
             'contents'=>['en'=>'Entrega en curso','es'=>'Entrega en curso','it'=>'Consegna in corso'],
             'url'=>$url,
+            'filters' => [ [ 'field'=>'tag','key'=>'wcof_role','relation'=>'=','value'=>'user' ] ],
             'include_external_user_ids' => [ (string)$uid ],
             'ttl'=>300
         ]);
@@ -1652,6 +1658,11 @@ final class WCOF_Plugin {
         </script>
         <?php
         return ob_get_clean();
+    }
+
+    public function account_push_button(){
+        if( empty($this->settings()['enable']) ) return;
+        echo do_shortcode('[wcof_push_button]');
     }
 
     /* ===== Push shortcodes ===== */


### PR DESCRIPTION
## Summary
- Target purchasing users in order status push notifications using role tags and OneSignal external IDs
- Surface an opt-in push button on WooCommerce account pages for user subscriptions
- Refine push subscription script to handle admin vs. customer messaging and associate user IDs on opt-in

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/push-button.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b700694c83328cc21c425d76791f