### PR TITLE
Add tip and scheduled delivery fields

### DIFF
--- a/assets/orders-admin.js
+++ b/assets/orders-admin.js
@@ -59,9 +59,10 @@
     const phone = htmlEscape(o.phone||'');
     const note = htmlEscape(o.note||'');
     const payment = htmlEscape(o.payment||'');
-    const metaHtml = o.meta && typeof o.meta === 'object'
-      ? Object.keys(o.meta).map(k=>`<div><strong>${htmlEscape(k)}:</strong> ${htmlEscape(o.meta[k])}</div>`).join('')
-      : '';
+    const meta = o.meta && typeof o.meta === 'object' ? Object.assign({}, o.meta) : {};
+    const tip = meta._wcof_tip; if(tip!==undefined){ delete meta._wcof_tip; }
+    const sched = meta._wcof_scheduled_time; if(sched!==undefined){ delete meta._wcof_scheduled_time; }
+    const metaHtml = Object.keys(meta).map(k=>`<div><strong>${htmlEscape(k)}:</strong> ${htmlEscape(meta[k])}</div>`).join('');
     return `<div class="wcof-card wcof-new" data-id="${htmlEscape(o.id||'')}" data-status="${htmlEscape(o.status||'')}">
       <div class="wcof-head" style="display:grid;grid-template-columns:8px 1fr auto auto auto;gap:14px;align-items:center;padding:16px">
         <div class="wcof-left ${statusBar(o.status||'wc-on-hold')}" style="grid-row:1 / span 3"></div>
@@ -78,6 +79,8 @@
 
             <div><strong>Telefono:</strong> ${phone} ${o.phone?`<a class=\"btn btn-phone\" href=\"tel:${encodeURIComponent(o.phone)}\" target=\"_blank\">\u260E\ufe0f</a>`:''}</div>
             ${payment?`<div><strong>Payment:</strong> ${payment}</div>`:''}
+            ${tip?`<div><strong>Tip:</strong> ${htmlEscape(tip)}</div>`:''}
+            ${sched?`<div><strong>Scheduled time:</strong> ${htmlEscape(sched)}</div>`:''}
             <div><strong>Note:</strong> ${note || '—'}</div>
             ${metaHtml}
           </div>

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -1015,12 +1015,16 @@ final class WCOF_Plugin {
         $addr_value  = '';
         $town_value  = '';
         $door_value  = '';
+        $tip_value   = '';
+        $time_value  = '';
         $resolved_value = '';
         $coords_value   = '';
         if( $checkout && method_exists($checkout, 'get_value') ){
             $addr_value    = $checkout->get_value('wcof_delivery_address');
             $town_value    = $checkout->get_value('wcof_delivery_town');
             $door_value    = $checkout->get_value('wcof_delivery_door');
+            $tip_value     = $checkout->get_value('wcof_tip');
+            $time_value    = $checkout->get_value('wcof_scheduled_time');
             $resolved_value = $checkout->get_value('wcof_delivery_resolved');
             $coords_value   = $checkout->get_value('wcof_delivery_coords');
         }
@@ -1139,6 +1143,19 @@ final class WCOF_Plugin {
             'required' => false,
             'label'    => __('Apartment or Door #','wc-order-flow'),
         ], $door_value);
+        woocommerce_form_field('wcof_tip', [
+            'type'     => 'number',
+            'class'    => [ 'form-row-first' ],
+            'required' => false,
+            'label'    => __('Tip amount','wc-order-flow'),
+            'custom_attributes' => [ 'step' => '0.01', 'min' => '0' ],
+        ], $tip_value);
+        woocommerce_form_field('wcof_scheduled_time', [
+            'type'     => 'time',
+            'class'    => [ 'form-row-last' ],
+            'required' => false,
+            'label'    => __('Desired delivery time','wc-order-flow'),
+        ], $time_value);
         // Error message container shown when the typed address is
         // outside the delivery area or cannot be resolved.
         echo '<p id="wcof-delivery-error" style="color:#dc2626;display:none;margin-top:4px"></p>';
@@ -1222,6 +1239,8 @@ final class WCOF_Plugin {
         $town = isset($_POST['wcof_delivery_town']) ? sanitize_text_field($_POST['wcof_delivery_town']) : '';
         $addr = isset($_POST['wcof_delivery_address']) ? sanitize_text_field($_POST['wcof_delivery_address']) : '';
         $door = isset($_POST['wcof_delivery_door']) ? sanitize_text_field($_POST['wcof_delivery_door']) : '';
+        $tip  = isset($_POST['wcof_tip']) ? floatval($_POST['wcof_tip']) : '';
+        $time = isset($_POST['wcof_scheduled_time']) ? sanitize_text_field($_POST['wcof_scheduled_time']) : '';
         if($town !== ''){
             $order->update_meta_data('_wcof_delivery_town', $town);
         }
@@ -1245,6 +1264,12 @@ final class WCOF_Plugin {
                 $order->update_meta_data('_wcof_delivery_coords', $coords);
             }
         }
+        if($tip !== '' && $tip >= 0){
+            $order->update_meta_data('_wcof_tip', wc_format_decimal($tip));
+        }
+        if($time !== ''){
+            $order->update_meta_data('_wcof_scheduled_time', $time);
+        }
         $order->save();
     }
 
@@ -1252,6 +1277,8 @@ final class WCOF_Plugin {
         $typed    = $order->get_meta('_wcof_delivery_address');
         $resolved = $order->get_meta('_wcof_delivery_resolved');
         $coords   = $order->get_meta('_wcof_delivery_coords');
+        $tip      = $order->get_meta('_wcof_tip');
+        $time     = $order->get_meta('_wcof_scheduled_time');
         if($typed){
             echo '<p><strong>'.esc_html__('Address','wc-order-flow').':</strong> '.esc_html($typed).'</p>';
         }
@@ -1260,6 +1287,12 @@ final class WCOF_Plugin {
         }
         if($coords){
             echo '<p><strong>'.esc_html__('Coordinates','wc-order-flow').':</strong> '.esc_html($coords).'</p>';
+        }
+        if($tip !== ''){
+            echo '<p><strong>'.esc_html__('Tip','wc-order-flow').':</strong> '.wc_price($tip, ['currency'=>$order->get_currency()]).'</p>';
+        }
+        if($time){
+            echo '<p><strong>'.esc_html__('Scheduled time','wc-order-flow').':</strong> '.esc_html($time).'</p>';
         }
     }
 
@@ -1282,6 +1315,8 @@ final class WCOF_Plugin {
         $typed    = $order->get_meta('_wcof_delivery_address');
         $resolved = $order->get_meta('_wcof_delivery_resolved');
         $coords   = $order->get_meta('_wcof_delivery_coords');
+        $tip      = $order->get_meta('_wcof_tip');
+        $time     = $order->get_meta('_wcof_scheduled_time');
         if($typed){
             $fields['wcof_delivery_address'] = [
                 'label' => __('Address','wc-order-flow'),
@@ -1298,6 +1333,18 @@ final class WCOF_Plugin {
             $fields['wcof_delivery_coords'] = [
                 'label' => __('Coordinates','wc-order-flow'),
                 'value' => $coords,
+            ];
+        }
+        if($tip !== ''){
+            $fields['wcof_tip'] = [
+                'label' => __('Tip','wc-order-flow'),
+                'value' => wc_price($tip, ['currency'=>$order->get_currency()]),
+            ];
+        }
+        if($time){
+            $fields['wcof_scheduled_time'] = [
+                'label' => __('Scheduled time','wc-order-flow'),
+                'value' => $time,
             ];
         }
         return $fields;


### PR DESCRIPTION
## Summary
- capture tip and desired delivery time on checkout
- save tip and schedule as order meta
- surface tip and schedule in admin, emails, and orders board

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/orders-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4b70212a48332a952774f97c3d962