### PR TITLE
Add analytics dashboard

### DIFF
--- a/assets/analytics.js
+++ b/assets/analytics.js
@@ -1,0 +1,13 @@
+(function(){
+  if(!window.WCOF_ANALYTICS) return;
+  const data = window.WCOF_ANALYTICS.topProducts || [];
+  const ctx = document.getElementById('wcof-analytics-chart');
+  if(!ctx) return;
+  const labels = data.map(p=>p.name);
+  const quantities = data.map(p=>p.qty);
+  new Chart(ctx, {
+    type: 'bar',
+    data: { labels: labels, datasets:[{ data: quantities, backgroundColor: '#4ade80' }] },
+    options: { responsive: true, plugins:{ legend:{ display:false } } }
+  });
+})();


### PR DESCRIPTION
## Summary
- add WCOF Analytics admin page with sales metrics and charts
- compute totals and product stats via custom SQL queries
- allow CSV export of analytics data

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/analytics.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68c4b7034e60833283cdea7c245b77fb