### PR TITLE
Use new license validation endpoint

### DIFF
--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -1025,7 +1025,7 @@ final class WCOF_Plugin {
             update_option(self::LICENSE_STATUS_KEY, 'invalid');
             return false;
         }
-        $response = wp_remote_get('https://license.example.com/validate?license_key=' . urlencode($key), ['timeout'=>15]);
+        $response = wp_remote_get('https://reeserva.growmydigital.com/key-check/?license_key=' . urlencode($key), ['timeout'=>15]);
         if(is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200){
             update_option(self::LICENSE_STATUS_KEY, 'invalid');
             return false;


### PR DESCRIPTION
## Summary
- update license validation to use `https://reeserva.growmydigital.com/key-check/`

## Testing
- `php -l wc-order-flow.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c54f44627c8332b7c0265852bdd019