### PR TITLE
Add customizable PWA install prompt

### DIFF
--- a/assets/pwa-install-prompt.css
+++ b/assets/pwa-install-prompt.css
@@ -1,0 +1,19 @@
+#wcof-install-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: #333;
+    padding: 12px;
+    text-align: center;
+    z-index: 9999;
+}
+#wcof-install-banner button {
+    background: #fff;
+    color: #333;
+    border: none;
+    padding: 8px 16px;
+    font-size: 16px;
+    border-radius: 4px;
+    cursor: pointer;
+}

--- a/assets/pwa-install-prompt.js
+++ b/assets/pwa-install-prompt.js
@@ -1,0 +1,21 @@
+(function(){
+    var deferredPrompt;
+    window.addEventListener('beforeinstallprompt', function(e){
+        e.preventDefault();
+        deferredPrompt = e;
+        var banner = document.createElement('div');
+        banner.id = 'wcof-install-banner';
+        var button = document.createElement('button');
+        button.id = 'wcof-install-button';
+        button.textContent = (window.wcofPwaPrompt && window.wcofPwaPrompt.text) ? window.wcofPwaPrompt.text : 'Download the app';
+        banner.appendChild(button);
+        document.body.appendChild(banner);
+        button.addEventListener('click', function(){
+            banner.parentNode.removeChild(banner);
+            if(deferredPrompt){
+                deferredPrompt.prompt();
+                deferredPrompt = null;
+            }
+        });
+    });
+})();

--- a/languages/wc-order-flow-en_US.po
+++ b/languages/wc-order-flow-en_US.po
@@ -6,3 +6,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgid "Download the app"
+msgstr "Download the app"
+
+msgid "Show install prompt"
+msgstr "Show install prompt"
+
+msgid "Install prompt text"
+msgstr "Install prompt text"

--- a/languages/wc-order-flow-es_ES.po
+++ b/languages/wc-order-flow-es_ES.po
@@ -299,3 +299,12 @@ msgstr "Comenzar a vender ahora"
 
 msgid "Keep the store closed for now"
 msgstr "Mantener la tienda cerrada por ahora"
+
+msgid "Download the app"
+msgstr "Descargar la app"
+
+msgid "Show install prompt"
+msgstr "Mostrar aviso de instalación"
+
+msgid "Install prompt text"
+msgstr "Texto del aviso de instalación"

--- a/languages/wc-order-flow-it_IT.po
+++ b/languages/wc-order-flow-it_IT.po
@@ -299,3 +299,12 @@ msgstr "Inizia a vendere ora"
 
 msgid "Keep the store closed for now"
 msgstr "Mantieni il negozio chiuso per ora"
+
+msgid "Download the app"
+msgstr "Scarica l'app"
+
+msgid "Show install prompt"
+msgstr "Mostra prompt di installazione"
+
+msgid "Install prompt text"
+msgstr "Testo del prompt di installazione"

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -212,6 +212,13 @@ echo '<meta name="theme-color" content="'.esc_attr($s['pwa_color']).'" />' . "\n
 if(!empty($s['pwa_icon'])){
 echo '<link rel="apple-touch-icon" href="'.esc_url($s['pwa_icon']).'" />' . "\n";
 }
+if(!empty($s['pwa_prompt'])){
+wp_enqueue_script('wcof-pwa-install', plugins_url('assets/pwa-install-prompt.js', __FILE__), [], '1.0', true);
+wp_localize_script('wcof-pwa-install', 'wcofPwaPrompt', [
+'text'=> $s['pwa_prompt_text']? $s['pwa_prompt_text']:esc_html__('Download the app','wc-order-flow')
+]);
+echo '<link rel="stylesheet" href="'.esc_url(plugins_url('assets/pwa-install-prompt.css', __FILE__)).'" />' . "\n";
+}
 }
 
     /* Avoid any 301/302 on SW files — redirects break registration */
@@ -1050,7 +1057,9 @@ echo '<link rel="apple-touch-icon" href="'.esc_url($s['pwa_icon']).'" />' . "\n"
             'pwa_enable'=>!empty($v['pwa_enable'])?1:0,
             'pwa_name'=>isset($v['pwa_name'])?sanitize_text_field($v['pwa_name']):'',
             'pwa_icon'=>isset($v['pwa_icon'])?esc_url_raw($v['pwa_icon']):'',
-            'pwa_color'=>isset($v['pwa_color'])?sanitize_hex_color($v['pwa_color']):''
+            'pwa_color'=>isset($v['pwa_color'])?sanitize_hex_color($v['pwa_color']):'',
+            'pwa_prompt'=>!empty($v['pwa_prompt'])?1:0,
+            'pwa_prompt_text'=>isset($v['pwa_prompt_text'])?sanitize_text_field($v['pwa_prompt_text']):''
         ];
         $days=['mon','tue','wed','thu','fri','sat','sun'];
         $out['open_days']=[];
@@ -1066,7 +1075,7 @@ echo '<link rel="apple-touch-icon" href="'.esc_url($s['pwa_icon']).'" />' . "\n"
             'notify_admin_new'=>1,'notify_user_processing'=>1,'notify_user_out'=>1,
             'address'=>'','open_days'=>[],'open_time'=>'09:00','close_time'=>'17:00','store_closed'=>0,'rider_see_processing'=>1,
             'postal_codes'=>'','delivery_radius'=>0,'delivery_polygon'=>'','language'=>'auto',
-            'pwa_enable'=>0,'pwa_name'=>'','pwa_icon'=>'','pwa_color'=>'#ffffff'
+            'pwa_enable'=>0,'pwa_name'=>'','pwa_icon'=>'','pwa_color'=>'#ffffff','pwa_prompt'=>1,'pwa_prompt_text'=>''
         ]);
     }
 
@@ -1544,6 +1553,8 @@ echo '<link rel="apple-touch-icon" href="'.esc_url($s['pwa_icon']).'" />' . "\n"
               <tr><th scope="row"><?php esc_html_e('App name', 'wc-order-flow'); ?></th><td><input type="text" class="regular-text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[pwa_name]" value="<?php echo esc_attr($s['pwa_name']); ?>" placeholder="<?php echo esc_attr(get_bloginfo('name')); ?>"/></td></tr>
               <tr><th scope="row"><?php esc_html_e('App icon URL', 'wc-order-flow'); ?></th><td><input type="text" class="regular-text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[pwa_icon]" value="<?php echo esc_attr($s['pwa_icon']); ?>" placeholder="https://example.com/icon.png"/></td></tr>
               <tr><th scope="row"><?php esc_html_e('Theme color', 'wc-order-flow'); ?></th><td><input type="text" class="regular-text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[pwa_color]" value="<?php echo esc_attr($s['pwa_color']); ?>" placeholder="#ffffff"/></td></tr>
+              <tr><th scope="row"><?php esc_html_e('Show install prompt', 'wc-order-flow'); ?></th><td><label><input type="checkbox" name="<?php echo esc_attr(self::OPTION_KEY); ?>[pwa_prompt]" value="1" <?php checked($s['pwa_prompt'],1); ?>/> <?php esc_html_e('Yes', 'wc-order-flow'); ?></label></td></tr>
+              <tr><th scope="row"><?php esc_html_e('Install prompt text', 'wc-order-flow'); ?></th><td><input type="text" class="regular-text" name="<?php echo esc_attr(self::OPTION_KEY); ?>[pwa_prompt_text]" value="<?php echo esc_attr($s['pwa_prompt_text']); ?>" placeholder="<?php esc_attr_e('Download the app', 'wc-order-flow'); ?>"/></td></tr>
             </table>
             <h2><?php esc_html_e('OneSignal', 'wc-order-flow'); ?></h2>
             <table class="form-table" role="presentation">


### PR DESCRIPTION
## Summary
- show banner prompting visitors to download the app when PWA is enabled
- allow admins to enable/disable and customize banner text
- localize strings and add styles for the install prompt

## Testing
- `php -l wc-order-flow.php`
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c573e6f3b4833284ac4ff9200cf6f8