### PR TITLE
Add mobile fallback for PWA install prompt

### DIFF
--- a/assets/pwa-install-prompt.js
+++ b/assets/pwa-install-prompt.js
@@ -1,8 +1,8 @@
 (function(){
     var deferredPrompt;
-    window.addEventListener('beforeinstallprompt', function(e){
-        e.preventDefault();
-        deferredPrompt = e;
+
+    function createBanner(){
+        if(document.getElementById('wcof-install-banner')) return;
         var banner = document.createElement('div');
         banner.id = 'wcof-install-banner';
         var button = document.createElement('button');
@@ -17,5 +17,21 @@
                 deferredPrompt = null;
             }
         });
+    }
+
+    window.addEventListener('beforeinstallprompt', function(e){
+        e.preventDefault();
+        deferredPrompt = e;
+        createBanner();
     });
+
+    if(/iphone|ipad|ipod|android/i.test(navigator.userAgent)){
+        window.addEventListener('load', function(){
+            setTimeout(function(){
+                if(!deferredPrompt && !window.matchMedia('(display-mode: standalone)').matches){
+                    createBanner();
+                }
+            }, 3000);
+        });
+    }
 })();


### PR DESCRIPTION
## Summary
- show custom install banner for mobile browsers even when `beforeinstallprompt` is missing
- refactor banner creation into reusable function

## Testing
- `node --check assets/pwa-install-prompt.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5804a7ce08332b5b0632f01d7bf27