### PR TITLE
Handle missing PWA install prompt

### DIFF
--- a/assets/pwa-install-prompt.js
+++ b/assets/pwa-install-prompt.js
@@ -5,18 +5,25 @@
         if(document.getElementById('wcof-install-banner')) return;
         var banner = document.createElement('div');
         banner.id = 'wcof-install-banner';
-        var button = document.createElement('button');
-        button.id = 'wcof-install-button';
-        button.textContent = (window.wcofPwaPrompt && window.wcofPwaPrompt.text) ? window.wcofPwaPrompt.text : 'Download the app';
-        banner.appendChild(button);
-        document.body.appendChild(banner);
-        button.addEventListener('click', function(){
-            banner.parentNode.removeChild(banner);
-            if(deferredPrompt){
+
+        if(deferredPrompt){
+            var button = document.createElement('button');
+            button.id = 'wcof-install-button';
+            button.textContent = (window.wcofPwaPrompt && window.wcofPwaPrompt.text) ? window.wcofPwaPrompt.text : 'Download the app';
+            banner.appendChild(button);
+            button.addEventListener('click', function(){
+                banner.parentNode.removeChild(banner);
                 deferredPrompt.prompt();
                 deferredPrompt = null;
-            }
-        });
+            });
+            document.body.appendChild(banner);
+        }else if(window.wcofPwaPrompt && window.wcofPwaPrompt.manual){
+            var info = document.createElement('p');
+            info.id = 'wcof-install-instructions';
+            info.textContent = window.wcofPwaPrompt.manual;
+            banner.appendChild(info);
+            document.body.appendChild(banner);
+        }
     }
 
     window.addEventListener('beforeinstallprompt', function(e){

--- a/languages/wc-order-flow-en_US.po
+++ b/languages/wc-order-flow-en_US.po
@@ -15,3 +15,6 @@ msgstr "Show install prompt"
 
 msgid "Install prompt text"
 msgstr "Install prompt text"
+
+msgid "Add this page to your home screen via your browser menu"
+msgstr "Add this page to your home screen via your browser menu"

--- a/languages/wc-order-flow-es_ES.po
+++ b/languages/wc-order-flow-es_ES.po
@@ -308,3 +308,6 @@ msgstr "Mostrar aviso de instalación"
 
 msgid "Install prompt text"
 msgstr "Texto del aviso de instalación"
+
+msgid "Add this page to your home screen via your browser menu"
+msgstr "Añade esta página a la pantalla de inicio desde el menú de tu navegador"

--- a/languages/wc-order-flow-it_IT.po
+++ b/languages/wc-order-flow-it_IT.po
@@ -308,3 +308,6 @@ msgstr "Mostra prompt di installazione"
 
 msgid "Install prompt text"
 msgstr "Testo del prompt di installazione"
+
+msgid "Add this page to your home screen via your browser menu"
+msgstr "Aggiungi questa pagina alla schermata iniziale dal menu del browser"

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -213,12 +213,13 @@ if(!empty($s['pwa_icon'])){
 echo '<link rel="apple-touch-icon" href="'.esc_url($s['pwa_icon']).'" />' . "\n";
 }
 if(!empty($s['pwa_prompt'])){
-wp_enqueue_script('wcof-pwa-install', plugins_url('assets/pwa-install-prompt.js', __FILE__), [], '1.0', true);
-wp_localize_script('wcof-pwa-install', 'wcofPwaPrompt', [
-'text'=> $s['pwa_prompt_text']? $s['pwa_prompt_text']:esc_html__('Download the app','wc-order-flow')
-]);
-echo '<link rel="stylesheet" href="'.esc_url(plugins_url('assets/pwa-install-prompt.css', __FILE__)).'" />' . "\n";
-}
+        wp_enqueue_script('wcof-pwa-install', plugins_url('assets/pwa-install-prompt.js', __FILE__), [], '1.0', true);
+        wp_localize_script('wcof-pwa-install', 'wcofPwaPrompt', [
+        'text'=> $s['pwa_prompt_text']? $s['pwa_prompt_text']:esc_html__('Download the app','wc-order-flow'),
+        'manual'=> esc_html__('Add this page to your home screen via your browser menu','wc-order-flow')
+        ]);
+        echo '<link rel="stylesheet" href="'.esc_url(plugins_url('assets/pwa-install-prompt.css', __FILE__)).'" />' . "\n";
+        }
 }
 
     /* Avoid any 301/302 on SW files — redirects break registration */


### PR DESCRIPTION
## Summary
- Show install button only when `beforeinstallprompt` is available
- Offer manual "Add to Home Screen" guidance if the browser doesn't support the prompt
- Localize instructions for English, Spanish and Italian

## Testing
- `node --check assets/pwa-install-prompt.js`
- `php -l wc-order-flow.php`
- `msgfmt languages/wc-order-flow-en_US.po -o /tmp/en_US.mo`
- `msgfmt languages/wc-order-flow-es_ES.po -o /tmp/es_ES.mo`
- `msgfmt languages/wc-order-flow-it_IT.po -o /tmp/it_IT.mo`


------
https://chatgpt.com/codex/tasks/task_e_68c5822b7f808332bdaa43679b4031ff