### PR TITLE
Add delivery/takeaway toggle and optimize checkout layout

### DIFF
--- a/assets/checkout-address.js
+++ b/assets/checkout-address.js
@@ -57,6 +57,9 @@
         var validInput = get('wcof_delivery_valid');
         var summaryEl = document.getElementById('wcof-resolved-display');
         var addressSelect = document.getElementById('wcof-address-select');
+        var serviceInput = get('wcof_service_type');
+        var deliveryFields = document.getElementById('wcof-delivery-details');
+        var toggleBtns = document.querySelectorAll('#wcof-service-toggle .wcof-mode-btn');
         if(!mapEl) return;
         var map = Leaflet.map(mapEl);
         Leaflet.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -358,6 +361,32 @@
             }
         }
 
+        toggleBtns.forEach(function(btn){
+            btn.addEventListener('click', function(){
+                updateMode(btn.getAttribute('data-mode'));
+            });
+        });
+        function updateMode(mode){
+            if(serviceInput) serviceInput.value = mode;
+            toggleBtns.forEach(function(b){
+                if(b.getAttribute('data-mode') === mode){ b.classList.add('selected'); }
+                else{ b.classList.remove('selected'); }
+            });
+            if(mode === 'takeaway'){
+                if(deliveryFields) deliveryFields.style.display = 'none';
+                if(townInput) townInput.required = false;
+                if(addrInput) addrInput.required = false;
+                if(validInput) validInput.value = '1';
+                toggleQuickPayButtons(true);
+            }else{
+                if(deliveryFields) deliveryFields.style.display = '';
+                if(townInput) townInput.required = true;
+                if(addrInput) addrInput.required = true;
+                if(validInput && (!coordInput || !coordInput.value)) validInput.value = '';
+                toggleQuickPayButtons(validInput && validInput.value==='1');
+            }
+        }
+        updateMode(serviceInput ? serviceInput.value : 'delivery');
         if(coordInput && coordInput.value){
             var parts = coordInput.value.split(',');
             if(parts.length === 2){

--- a/assets/checkout.css
+++ b/assets/checkout.css
@@ -47,3 +47,32 @@
   box-shadow: 0 0 0 3px rgba(79,70,229,0.15);
 }
 
+/* Stack form fields in a single column */
+.woocommerce-checkout .form-row-first,
+.woocommerce-checkout .form-row-last {
+  float: none;
+  width: 100%;
+}
+
+/* Hide postcode field */
+#billing_postcode_field { display: none; }
+
+/* Delivery/Takeaway toggle */
+#wcof-service-toggle {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+#wcof-service-toggle .wcof-mode-btn {
+  flex: 1;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fff;
+  cursor: pointer;
+}
+#wcof-service-toggle .wcof-mode-btn.selected {
+  border-color: #4f46e5;
+  background: #eef;
+}
+


### PR DESCRIPTION
## Summary
- Add delivery/takeaway toggle on checkout that hides address fields when take away is selected
- Stack checkout fields in a single column and hide postal code for cleaner mobile layout
- Update validation and order saving to respect chosen service type

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/checkout-address.js`


------
https://chatgpt.com/codex/tasks/task_e_68c74e32b50483329d357711e3757023