### PR TITLE
Load admin stylesheet and remove inline CSS

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -1,0 +1,91 @@
+/* Orders admin */
+#wcof-order-list{display:flex;flex-direction:column;gap:18px;--wcf-card:#ffffff;--wcf-border:#e5e7eb;--wcf-shadow:0 6px 24px rgba(15,23,42,.06);--wcf-muted:#475569;}
+#wcof-order-list .wcof-card{background:var(--wcf-card);border:1px solid var(--wcf-border);border-radius:18px;box-shadow:var(--wcf-shadow);overflow:hidden}
+#wcof-order-list .wcof-head{display:grid;grid-template-columns:8px 1fr auto auto auto;gap:14px;align-items:center;padding:16px}
+#wcof-order-list .wcof-left{grid-column:1/2;width:6px;height:100%;border-radius:6px;grid-row:1/span 3}
+#wcof-order-list .st-await{background:linear-gradient(180deg,#fef08a,#facc15)}
+#wcof-order-list .st-proc{background:linear-gradient(180deg,#fed7aa,#fb923c)}
+#wcof-order-list .st-out{background:linear-gradient(180deg,#bfdbfe,#60a5fa)}
+#wcof-order-list .st-comp{background:linear-gradient(180deg,#a7f3d0,#10b981)}
+#wcof-order-list .st-rej{background:linear-gradient(180deg,#fecaca,#ef4444)}
+#wcof-order-list .wcof-title{margin:0;font-weight:600}
+#wcof-order-list .wcof-badge{display:inline-block;padding:.25rem .6rem;border-radius:8px;background:#f1f5f9;border:1px solid #cbd5e1;color:#1e293b;font-size:12px;margin-left:6px;font-weight:500}
+#wcof-order-list .wcof-arrival{display:inline-block;padding:.35rem .6rem;border-radius:8px;background:#ecfeff;border:1px solid #a5f3fc;color:#0e7490;font-weight:600}
+#wcof-order-list .wcof-items{grid-column:2/6;padding:12px 16px;background:#f9fafb;border-top:1px dashed var(--wcf-border)}
+#wcof-order-list .wcof-actions{display:flex;gap:8px;flex-wrap:wrap;justify-self:end;grid-column:2/6}
+#wcof-order-list .wcof-eta{width:90px;border:1px solid var(--wcf-border);border-radius:8px;padding:.5rem .55rem;font-size:14px}
+#wcof-order-list .btn{border:none;border-radius:8px;padding:.5rem .85rem;font-weight:600;font-size:14px;color:#fff;cursor:pointer;transition:background .2s;display:inline-flex;align-items:center;justify-content:center;vertical-align:middle;text-decoration:none}
+#wcof-order-list .btn-approve{background:#3b82f6}
+#wcof-order-list .btn-approve:hover{background:#2563eb}
+#wcof-order-list .btn-reject{background:#94a3b8}
+#wcof-order-list .btn-reject:hover{background:#6b7280}
+#wcof-order-list .btn-out{background:#f59e0b}
+#wcof-order-list .btn-out:hover{background:#d97706}
+#wcof-order-list .btn-complete{background:#10b981}
+#wcof-order-list .btn-complete:hover{background:#059669}
+#wcof-order-list .btn-toggle{background:#6b7280}
+#wcof-order-list .btn-toggle:hover{background:#4b5563}
+#wcof-order-list .btn-map{background:#3b82f6}
+#wcof-order-list .btn-map:hover{background:#2563eb}
+#wcof-order-list .btn-phone{background:#10b981}
+#wcof-order-list .btn-phone:hover{background:#059669}
+#wcof-order-list .wcof-info{margin-top:8px;font-size:14px;color:#334155}
+#wcof-order-list .wcof-info div{margin-top:4px}
+#wcof-order-list .wcof-address-extra{font-size:12px;color:#64748b;margin-top:2px}
+#wcof-order-list .wcof-map-buttons{margin-top:4px;display:flex;gap:4px;flex-wrap:wrap}
+#wcof-order-list .wcof-item{display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px dashed #ececec}
+#wcof-order-list .wcof-item:last-child{border-bottom:0}
+#wcof-order-list .wcof-new{animation:wcofPulse 1s ease-in-out 5;background:#ecfdf5}
+@keyframes wcofPulse{0%{background:#d1fae5}50%{background:#ecfdf5}100%{background:#d1fae5}}
+@media (max-width:760px){
+  #wcof-order-list .wcof-head{display:flex;flex-direction:column;align-items:stretch;gap:10px;padding:14px}
+  #wcof-order-list .wcof-left{display:none}
+  #wcof-order-list .wcof-eta{width:100%}
+  #wcof-order-list .btn{width:100%;padding:12px 14px;font-size:16px}
+  #wcof-order-list .wcof-actions{display:grid;grid-template-columns:1fr;gap:8px;width:100%}
+  #wcof-order-list .wcof-arrival{align-self:flex-start}
+  #wcof-order-list .wcof-title{font-size:16px}
+}
+@media (max-width:380px){
+  #wcof-order-list .wcof-title{font-size:15px}
+}
+#wcof-order-list .wcof-sound{position:fixed;right:14px;bottom:14px;background:#111;color:#fff;border-radius:24px;padding:.6rem .95rem;cursor:pointer;opacity:.9;z-index:9999;display:none}
+
+/* Product manager */
+#wcof-product-manager{font-family:sans-serif;display:flex;flex-direction:column;gap:18px;--wcf-card:#ffffff;--wcf-border:#e5e7eb;--wcf-shadow:0 6px 24px rgba(15,23,42,.06);--wcf-accent:#3b82f6;--wcf-accent-light:#e0f2fe;}
+#wcof-product-manager .wcof-cat{background:var(--wcf-card);border:1px solid var(--wcf-border);border-radius:18px;box-shadow:var(--wcf-shadow);overflow:hidden}
+#wcof-product-manager .wcof-cat-header{display:flex;justify-content:space-between;align-items:center;padding:14px;background:var(--wcf-accent-light);font-weight:700}
+#wcof-product-manager .wcof-prod-list{display:flex;flex-direction:column;gap:10px;padding:14px;background:var(--wcf-accent-light);border-top:1px dashed var(--wcf-border)}
+#wcof-product-manager .wcof-prod{display:flex;justify-content:space-between;align-items:center;gap:12px;background:#fff;border:1px solid var(--wcf-border);border-radius:12px;padding:10px}
+#wcof-product-manager .wcof-prod-title{font-weight:600}
+#wcof-product-manager .wcof-active{display:flex;align-items:center;gap:6px}
+#wcof-product-manager .btn{border:none;border-radius:12px;padding:.55rem .9rem;font-weight:700;color:#fff;cursor:pointer}
+#wcof-product-manager .btn-add{background:var(--wcf-accent)}
+#wcof-product-manager .btn-del{background:#ef4444}
+#wcof-product-manager .btn-edit{background:#10b981}
+#wcof-product-manager .wcof-form-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.5);display:flex;justify-content:center;align-items:center;padding:20px;z-index:9999}
+#wcof-product-manager .wcof-prod-form{display:flex;flex-direction:column;gap:14px;background:#fff;padding:24px;border-radius:16px;box-shadow:var(--wcf-shadow);width:100%;max-width:600px}
+#wcof-product-manager .wcof-prod-form input,#wcof-product-manager .wcof-prod-form textarea,#wcof-product-manager .wcof-prod-form select{width:100%;padding:12px;border:1px solid #cbd5e1;border-radius:8px;font-size:1rem;box-sizing:border-box}
+#wcof-product-manager .wcof-prod-form textarea{min-height:120px}
+#wcof-product-manager .wcof-prod-form textarea.wcof-allergens{min-height:80px}
+#wcof-product-manager .wcof-img-field{text-align:center;display:flex;flex-direction:column;gap:10px}
+#wcof-product-manager .wcof-img-preview{width:200px;height:200px;border-radius:12px;object-fit:cover;display:none;margin:0 auto}
+#wcof-product-manager .wcof-upload-btn{background:var(--wcf-accent);color:#fff;border:none;border-radius:8px;padding:.55rem .9rem;font-weight:700;cursor:pointer}
+#wcof-product-manager .wcof-prod-form button{padding:12px;background:var(--wcf-accent);color:#fff;border:none;border-radius:8px;font-size:1rem}
+#wcof-product-manager .wcof-switch{position:relative;display:inline-block;width:40px;height:22px}
+#wcof-product-manager .wcof-switch input{opacity:0;width:0;height:0}
+#wcof-product-manager .wcof-slider{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background:#cbd5e1;transition:.2s;border-radius:22px}
+#wcof-product-manager .wcof-slider:before{position:absolute;content:"";height:18px;width:18px;left:2px;bottom:2px;background:#fff;transition:.2s;border-radius:50%}
+#wcof-product-manager .wcof-switch input:checked + .wcof-slider{background:#22c55e}
+#wcof-product-manager .wcof-switch input:checked + .wcof-slider:before{transform:translateX(18px)}
+
+/* Store settings */
+.wcof-store-settings{font-family:sans-serif;max-width:600px;margin:0 auto;--wcf-card:#ffffff;--wcf-border:#e5e7eb;--wcf-shadow:0 6px 24px rgba(15,23,42,.06);--wcf-accent:#3b82f6;--wcf-accent-light:#e0f2fe;background:var(--wcf-accent-light);padding:24px;border-radius:16px;box-shadow:var(--wcf-shadow)}
+.wcof-store-settings input[type=text],
+.wcof-store-settings input[type=email],
+.wcof-store-settings input[type=password],
+.wcof-store-settings input[type=number],
+.wcof-store-settings input[type=time],
+.wcof-store-settings select{width:100%;padding:12px;border:1px solid var(--wcf-border);border-radius:8px;box-sizing:border-box}
+.wcof-store-settings input[type=time]{width:auto;display:inline-block}
+.wcof-store-settings button{padding:12px;background:var(--wcf-accent);color:#fff;border:none;border-radius:8px;font-size:1rem;cursor:pointer}


### PR DESCRIPTION
## Summary
- Centralize styling for admin shortcodes in `assets/admin.css`
- Dynamically enqueue the stylesheet with plugin version for cache busting
- Drop inline `<style>` blocks from admin-facing shortcodes

## Testing
- `php -l wc-order-flow.php`

------
https://chatgpt.com/codex/tasks/task_e_68c74daa90d88332bc9fe7b11bec9fb8