### PR TITLE
Ensure order admin board spans full width

### DIFF
--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -796,7 +796,7 @@ exit;
         ob_start(); ?>
         <style>
           :root{ --wcf-card:#ffffff; --wcf-border:#e5e7eb; --wcf-shadow:0 6px 24px rgba(15,23,42,.06); --wcf-muted:#475569;}
-          #wcof-order-list{width:100vw;margin-left:calc(50% - 50vw)}
+          #wcof-order-list{width:100vw;max-width:none;margin-left:calc(50% - 50vw)}
           .wcof-wrap{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;width:100%}
           .wcof-col{display:flex;flex-direction:column;gap:18px}
           .wcof-col-full{grid-column:1/-1}


### PR DESCRIPTION
## Summary
- Allow order list container to expand across entire viewport by removing max-width restriction

## Testing
- `php -l wc-order-flow.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7d101a5d8833286a74809a501dcde