### PR TITLE
Remove tip field and hide generated address summary

### DIFF
--- a/assets/checkout-address.js
+++ b/assets/checkout-address.js
@@ -56,6 +56,7 @@
         var coordInput = get('wcof_delivery_coords');
         var validInput = get('wcof_delivery_valid');
         var summaryEl = document.getElementById('wcof-resolved-display');
+        if(summaryEl) summaryEl.style.display='none';
         var addressSelect = document.getElementById('wcof-address-select');
         var serviceInput = get('wcof_service_type');
         var deliveryFields = document.getElementById('wcof-delivery-details');
@@ -196,10 +197,7 @@
                     hideError();
                     var full = data.display_name || '';
                     if(resolvedInput) resolvedInput.value = full;
-                    if(summaryEl){
-                        summaryEl.textContent = full + ' (' + latlng.lat + ',' + latlng.lng + ')';
-                        summaryEl.style.display = 'block';
-                    }
+                    if(summaryEl){ summaryEl.textContent=''; summaryEl.style.display='none'; }
                     document.querySelector('#billing_postcode').value = pc;
                     document.querySelector('#billing_address_1').value = full;
                     document.querySelector('#billing_city').value = addr.city || addr.town || addr.village || '';
@@ -330,10 +328,7 @@
                 if(coordInput) coordInput.value = opt.getAttribute('data-coords') || '';
                 var r = opt.getAttribute('data-resolved') || '';
                 var c = opt.getAttribute('data-coords') || '';
-                if(summaryEl){
-                    if(r && c){ summaryEl.textContent = r + ' (' + c + ')'; summaryEl.style.display='block'; }
-                    else { summaryEl.textContent=''; summaryEl.style.display='none'; }
-                }
+                if(summaryEl){ summaryEl.textContent=''; summaryEl.style.display='none'; }
                 if(c){
                     suppressSearch = true;
                     var parts = c.split(',');
@@ -395,10 +390,7 @@
                 if(promise && typeof promise.then === 'function' && typedAddress){
                     promise.then(function(){ addrInput.value = typedAddress; });
                 }
-                if(resolvedInput && resolvedInput.value && summaryEl){
-                    summaryEl.textContent = resolvedInput.value + ' (' + coordInput.value + ')';
-                    summaryEl.style.display = 'block';
-                }
+                if(summaryEl){ summaryEl.textContent=''; summaryEl.style.display='none'; }
             }
         }else if(townInput.value && addrInput.value){
             // Coordinates not yet known but we have text fields

--- a/assets/checkout.css
+++ b/assets/checkout.css
@@ -76,3 +76,19 @@
   background: #eef;
 }
 
+/* Improve toggle interaction */
+#wcof-service-toggle .wcof-mode-btn {
+  transition: background .2s, border-color .2s;
+}
+#wcof-service-toggle .wcof-mode-btn:hover {
+  border-color: #4f46e5;
+}
+
+/* Spacing and hidden generated address text */
+#wcof-checkout-address .form-row-wide {
+  margin-bottom: 12px;
+}
+#wcof-resolved-display {
+  display: none;
+}
+

--- a/assets/orders-admin.js
+++ b/assets/orders-admin.js
@@ -67,7 +67,6 @@
     const note = htmlEscape(o.note||'');
     const payment = htmlEscape(o.payment||'');
     const meta = o.meta && typeof o.meta === 'object' ? Object.assign({}, o.meta) : {};
-    const tip = meta._wcof_tip; if(tip!==undefined){ delete meta._wcof_tip; }
     const sched = meta._wcof_scheduled_time; if(sched!==undefined){ delete meta._wcof_scheduled_time; }
     const serviceType = meta._wcof_service_type === 'takeaway' ? 'takeaway' : 'delivery';
     delete meta._wcof_service_type;
@@ -89,7 +88,6 @@
 
             <div><strong>Telefono:</strong> ${phone} ${o.phone?`<a class=\"btn btn-phone\" href=\"tel:${encodeURIComponent(o.phone)}\" target=\"_blank\">\u260E\ufe0f</a>`:''}</div>
             ${payment?`<div><strong>Payment:</strong> ${payment}</div>`:''}
-            ${tip?`<div><strong>Tip:</strong> ${htmlEscape(tip)}</div>`:''}
             ${sched?`<div><strong>Scheduled time:</strong> ${htmlEscape(sched)}</div>`:''}
             <div><strong>Note:</strong> ${note || '—'}</div>
             ${metaHtml}

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -1136,7 +1136,6 @@ exit;
         $addr_value  = '';
         $town_value  = '';
         $door_value  = '';
-        $tip_value   = '';
         $time_value  = '';
         $resolved_value = '';
         $coords_value   = '';
@@ -1144,7 +1143,6 @@ exit;
             $addr_value    = $checkout->get_value('wcof_delivery_address');
             $town_value    = $checkout->get_value('wcof_delivery_town');
             $door_value    = $checkout->get_value('wcof_delivery_door');
-            $tip_value     = $checkout->get_value('wcof_tip');
             $time_value    = $checkout->get_value('wcof_scheduled_time');
             $resolved_value = $checkout->get_value('wcof_delivery_resolved');
             $coords_value   = $checkout->get_value('wcof_delivery_coords');
@@ -1275,22 +1273,10 @@ exit;
             'required' => false,
             'label'    => __('Apartment or Door #','wc-order-flow'),
         ], $door_value);
-        woocommerce_form_field('wcof_tip', [
-            'type'     => 'number',
-            'class'    => [ 'form-row-wide' ],
-            'required' => false,
-            'label'    => __('Tip amount','wc-order-flow'),
-            'custom_attributes' => [ 'step' => '0.01', 'min' => '0' ],
-        ], $tip_value);
         // Error message container shown when the typed address is
         // outside the delivery area or cannot be resolved.
         echo '<p id="wcof-delivery-error" style="color:#dc2626;display:none;margin-top:4px"></p>';
-        // Display resolved address and coordinates once found.
-        $summary = '';
-        if($resolved_value && $coords_value){
-            $summary = esc_html($resolved_value) . ' (' . esc_html($coords_value) . ')';
-        }
-        echo '<p id="wcof-resolved-display" style="margin-top:4px;'.($summary ? '' : 'display:none;').'">'.$summary.'</p>';
+        echo '<p id="wcof-resolved-display" style="display:none;"></p>';
         if( count($prev_addresses) > 0 ){
             echo '<p><label for="wcof-address-select">'.esc_html__('Select from your addresses','wc-order-flow').'</label>';
             echo '<select id="wcof-address-select" style="width:100%">';
@@ -1412,7 +1398,6 @@ exit;
         $town = isset($_POST['wcof_delivery_town']) ? sanitize_text_field($_POST['wcof_delivery_town']) : '';
         $addr = isset($_POST['wcof_delivery_address']) ? sanitize_text_field($_POST['wcof_delivery_address']) : '';
         $door = isset($_POST['wcof_delivery_door']) ? sanitize_text_field($_POST['wcof_delivery_door']) : '';
-        $tip  = isset($_POST['wcof_tip']) ? floatval($_POST['wcof_tip']) : '';
         $time = isset($_POST['wcof_scheduled_time']) ? sanitize_text_field($_POST['wcof_scheduled_time']) : '';
         if($service === 'takeaway'){
             if($time !== ''){
@@ -1450,9 +1435,6 @@ exit;
                 $order->update_meta_data('_wcof_delivery_coords', $coords);
             }
         }
-        if($tip !== '' && $tip >= 0){
-            $order->update_meta_data('_wcof_tip', wc_format_decimal($tip));
-        }
         if($time !== ''){
             $order->update_meta_data('_wcof_scheduled_time', $time);
         }
@@ -1463,7 +1445,6 @@ exit;
         $typed    = $order->get_meta('_wcof_delivery_address');
         $resolved = $order->get_meta('_wcof_delivery_resolved');
         $coords   = $order->get_meta('_wcof_delivery_coords');
-        $tip      = $order->get_meta('_wcof_tip');
         $time     = $order->get_meta('_wcof_scheduled_time');
         if($typed){
             echo '<p><strong>'.esc_html__('Address','wc-order-flow').':</strong> '.esc_html($typed).'</p>';
@@ -1473,9 +1454,6 @@ exit;
         }
         if($coords){
             echo '<p><strong>'.esc_html__('Coordinates','wc-order-flow').':</strong> '.esc_html($coords).'</p>';
-        }
-        if($tip !== ''){
-            echo '<p><strong>'.esc_html__('Tip','wc-order-flow').':</strong> '.wc_price($tip, ['currency'=>$order->get_currency()]).'</p>';
         }
         if($time){
             echo '<p><strong>'.esc_html__('Scheduled time','wc-order-flow').':</strong> '.esc_html($time).'</p>';
@@ -1501,7 +1479,6 @@ exit;
         $typed    = $order->get_meta('_wcof_delivery_address');
         $resolved = $order->get_meta('_wcof_delivery_resolved');
         $coords   = $order->get_meta('_wcof_delivery_coords');
-        $tip      = $order->get_meta('_wcof_tip');
         $time     = $order->get_meta('_wcof_scheduled_time');
         if($typed){
             $fields['wcof_delivery_address'] = [
@@ -1519,12 +1496,6 @@ exit;
             $fields['wcof_delivery_coords'] = [
                 'label' => __('Coordinates','wc-order-flow'),
                 'value' => $coords,
-            ];
-        }
-        if($tip !== ''){
-            $fields['wcof_tip'] = [
-                'label' => __('Tip','wc-order-flow'),
-                'value' => wc_price($tip, ['currency'=>$order->get_currency()]),
             ];
         }
         if($time){


### PR DESCRIPTION
## Summary
- remove tip amount field from checkout, order meta and admin
- hide auto-generated address text and polish checkout styles

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/checkout-address.js`
- `node --check assets/orders-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7ea3f99cc833288701e4acafbf0a1