### PR TITLE
Fix map centering and hide order meta

### DIFF
--- a/assets/checkout-address.js
+++ b/assets/checkout-address.js
@@ -118,6 +118,7 @@
             fetch('https://nominatim.openstreetmap.org/search?format=json&limit=1&q='+encodeURIComponent(store))
                 .then(function(r){ return r.json(); })
                 .then(function(d){
+                    if(marker) return; // don't override existing marker view
                     if(Array.isArray(d) && d[0]){
                         var item = d[0];
                         if(item.boundingbox){
@@ -133,6 +134,7 @@
             fetch('https://nominatim.openstreetmap.org/search?format=json&limit=1&postalcode='+encodeURIComponent(allowed[0]))
                 .then(function(r){ return r.json(); })
                 .then(function(d){
+                    if(marker) return; // don't override existing marker view
                     if(Array.isArray(d) && d[0]){
                         var item = d[0];
                         if(item.boundingbox){

--- a/assets/orders-admin.js
+++ b/assets/orders-admin.js
@@ -69,11 +69,9 @@
     const note = htmlEscape(o.note||'');
     const payment = htmlEscape(o.payment||'');
     const meta = o.meta && typeof o.meta === 'object' ? Object.assign({}, o.meta) : {};
-    const sched = meta._wcof_scheduled_time; if(sched!==undefined){ delete meta._wcof_scheduled_time; }
+    const sched = meta._wcof_scheduled_time;
     const serviceType = meta._wcof_service_type === 'takeaway' ? 'takeaway' : 'delivery';
-    delete meta._wcof_service_type;
     const serviceHtml = serviceType === 'takeaway' ? '🛍️ TAKE AWAY' : '🛵';
-    const metaHtml = Object.keys(meta).map(k=>`<div><strong>${htmlEscape(k)}:</strong> ${htmlEscape(meta[k])}</div>`).join('');
     return `<div class="wcof-card wcof-new" data-id="${htmlEscape(o.id||'')}" data-status="${htmlEscape(o.status||'')}" data-eta="${htmlEscape(o.eta||'')}">
       <div class="wcof-head" style="display:grid;grid-template-columns:8px 1fr auto auto auto;gap:14px;align-items:center;padding:16px">
         <div class="wcof-left ${statusBar(o.status||'wc-on-hold')}" style="grid-row:1 / span 3"></div>
@@ -94,7 +92,6 @@
             ${payment?`<div><strong>Payment:</strong> ${payment}</div>`:''}
             ${sched?`<div><strong>Scheduled time:</strong> ${htmlEscape(sched)}</div>`:''}
             <div><strong>Note:</strong> ${note || '—'}</div>
-            ${metaHtml}
           </div>
         </div>
         <div class="wcof-actions" style="grid-column:2 / 6">${actionButtons(o)}</div>


### PR DESCRIPTION
## Summary
- Avoid re-centering map when a customer address marker already exists
- Remove display of order meta fields from live orders board

## Testing
- `node --check assets/checkout-address.js`
- `node --check assets/orders-admin.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f6b197548332a32780526142c0de