### PR TITLE
Show typed address and default ETA

### DIFF
--- a/assets/checkout-address.js
+++ b/assets/checkout-address.js
@@ -200,11 +200,21 @@
                     var full = data.display_name || '';
                     if(resolvedInput) resolvedInput.value = full;
                     if(summaryEl){ summaryEl.textContent=''; summaryEl.style.display='none'; }
+                    var typedAddr = addrInput.value.trim();
+                    if(doorInput && doorInput.value.trim()){
+                        var doorVal = doorInput.value.trim();
+                        if(typedAddr.indexOf(doorVal) === -1){ typedAddr += (typedAddr?' ':'') + doorVal; }
+                    }
+                    var townVal = townInput.value.trim();
                     document.querySelector('#billing_postcode').value = pc;
-                    document.querySelector('#billing_address_1').value = full;
-                    document.querySelector('#billing_city').value = addr.city || addr.town || addr.village || '';
+                    document.querySelector('#billing_address_1').value = typedAddr;
+                    document.querySelector('#billing_city').value = townVal || addr.city || addr.town || addr.village || '';
                     document.querySelector('#billing_country').value = (addr.country_code || '').toUpperCase();
                     document.querySelector('#billing_state').value = '';
+                    document.querySelector('#shipping_postcode').value = pc;
+                    document.querySelector('#shipping_address_1').value = typedAddr;
+                    document.querySelector('#shipping_city').value = townVal || addr.city || addr.town || addr.village || '';
+                    document.querySelector('#shipping_country').value = (addr.country_code || '').toUpperCase();
                     document.querySelector('#shipping_state').value = '';
                     lastValid = latlng;
                     if(validInput) validInput.value='1';

--- a/assets/orders-admin.js
+++ b/assets/orders-admin.js
@@ -43,7 +43,8 @@
   }
   function actionButtons(o){
     if(o.status==='wc-on-hold'){
-      return `<input type="number" min="0" step="1" placeholder="ETA min" class="wcof-eta">
+      const defEta = parseInt(o.eta,10) || WCOF_ORD.wait_min || '';
+      return `<input type="number" min="0" step="1" placeholder="ETA min" value="${htmlEscape(defEta)}" class="wcof-eta">
               <button class="btn btn-approve" data-action="approve" data-url="${htmlEscape(o.approve_url||'')}">Approva</button>
               <button class="btn btn-reject" data-action="reject" data-url="${htmlEscape(o.reject_url||'')}">Rifiuta</button>`;
     } else if(o.status==='wc-processing'){
@@ -72,7 +73,8 @@
     const sched = meta._wcof_scheduled_time;
     const serviceType = meta._wcof_service_type === 'takeaway' ? 'takeaway' : 'delivery';
     const serviceHtml = serviceType === 'takeaway' ? '🛍️ TAKE AWAY' : '🛵';
-    return `<div class="wcof-card wcof-new" data-id="${htmlEscape(o.id||'')}" data-status="${htmlEscape(o.status||'')}" data-eta="${htmlEscape(o.eta||'')}">
+    const etaVal = parseInt(o.eta,10) || (o.status==='wc-on-hold' ? WCOF_ORD.wait_min || '' : '');
+    return `<div class="wcof-card wcof-new" data-id="${htmlEscape(o.id||'')}" data-status="${htmlEscape(o.status||'')}" data-eta="${htmlEscape(etaVal)}">
       <div class="wcof-head" style="display:grid;grid-template-columns:8px 1fr auto auto auto;gap:14px;align-items:center;padding:16px">
         <div class="wcof-left ${statusBar(o.status||'wc-on-hold')}" style="grid-row:1 / span 3"></div>
         <div class="wcof-meta">


### PR DESCRIPTION
## Summary
- Use customer-typed address for billing info rather than geocoded display name
- Pre-fill ETA fields with store's minimum wait time for quick approval

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/orders-admin.js`
- `node --check assets/checkout-address.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7f7a16e5c8332b45dab7516e98248