### PR TITLE
Display order details after marking as out for delivery

### DIFF
--- a/assets/orders-admin.js
+++ b/assets/orders-admin.js
@@ -190,7 +190,7 @@
             const badge = card.querySelector('.wcof-badge');
             if(badge) badge.textContent = statusName('wc-out-for-delivery');
             const items = card.querySelector('.wcof-items');
-            if(items) items.style.display = 'none';
+            if(items) items.style.display = 'block';
             const etaIn = card.querySelector('.wcof-eta');
             const btnAp = card.querySelector('.btn-approve');
             if(etaIn) etaIn.remove();


### PR DESCRIPTION
## Summary
- Show order details immediately when an order is marked "In Consegna" by keeping the item section visible.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l wc-order-flow.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7fb28e33c8332a5bce657bda28753