### PR TITLE
Add rider push notification and tagging

### DIFF
--- a/assets/onesignal-init.js
+++ b/assets/onesignal-init.js
@@ -28,6 +28,7 @@
       notifyButton: { enable: false }
     });
     if(WCOF_PUSH.isAdmin){ OneSignal.sendTag('wcof_role','admin'); }
+    else if(WCOF_PUSH.isRider){ OneSignal.sendTag('wcof_role','rider'); }
     else { OneSignal.sendTag('wcof_role','user'); }
     if(WCOF_PUSH.userId){ OneSignal.setExternalUserId(String(WCOF_PUSH.userId)); }
   });


### PR DESCRIPTION
## Summary
- notify riders when orders move to processing via new `push_rider_order_ready` method
- tag OneSignal users with `wcof_role=rider` when they have `wcof_rider` capability

## Testing
- `php -l wc-order-flow.php`
- `node --check assets/onesignal-init.js`


------
https://chatgpt.com/codex/tasks/task_e_68c801f0935c8332ae185d5c01f74253