### PR TITLE
Handle OneSignal subscription changes in push button

### DIFF
--- a/assets/push-button.js
+++ b/assets/push-button.js
@@ -31,18 +31,31 @@
         OneSignal.isPushNotificationsEnabled(function(enabled){
           if(enabled){
             OneSignal.setSubscription(false);
-            setTimeout(refresh, 800);
           } else {
             if(window.WCOF_PUSH && WCOF_PUSH.userId){
               OneSignal.setExternalUserId(String(WCOF_PUSH.userId));
             }
-            OneSignal.showSlidedownPrompt();
-            setTimeout(refresh, 1200);
+            if(Notification.permission === 'granted'){
+              if(typeof OneSignal.registerForPushNotifications === 'function'){
+                OneSignal.registerForPushNotifications();
+              } else {
+                OneSignal.setSubscription(true);
+              }
+            } else {
+              OneSignal.showSlidedownPrompt();
+            }
           }
         });
       });
     });
   }
 
-  setTimeout(refresh, 800);
+  (function waitForOneSignal(){
+    if(!window.OneSignal){ setTimeout(waitForOneSignal, 400); return; }
+    OneSignal.push(function(){
+      OneSignal.on('subscriptionChange', refresh);
+    });
+  })();
+
+  refresh();
 })();


### PR DESCRIPTION
## Summary
- register for push notifications when permission already granted
- refresh push button state using OneSignal `subscriptionChange`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c8243de2c08332a0f60603d7c67380