### PR TITLE
Flush rewrite rules when enabling push notifications

### DIFF
--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -1051,6 +1051,16 @@ exit;
             'wait_min'=>isset($v['wait_min'])?absint($v['wait_min']):0,
             'wait_max'=>isset($v['wait_max'])?absint($v['wait_max']):0
         ];
+
+        // If push notifications are being enabled for the first time, ensure
+        // the service worker rewrite rules are registered and flushed so the
+        // worker files are immediately available at the site root.
+        $prev = get_option(self::OPTION_KEY, []);
+        $was_enabled = !empty($prev['enable']);
+        if (!$was_enabled && !empty($out['enable'])) {
+            $this->register_sw_rewrite();
+            flush_rewrite_rules();
+        }
         $days=['mon','tue','wed','thu','fri','sat','sun'];
         $out['open_days']=[];
         if(!empty($v['open_days']) && is_array($v['open_days'])){


### PR DESCRIPTION
## Summary
- Confirm activation registers service worker rewrites and flushes rewrite rules
- Flush rewrite rules automatically the first time push notifications are enabled so service worker files are immediately accessible

## Testing
- `php -l wc-order-flow.php`


------
https://chatgpt.com/codex/tasks/task_e_68c826f5b94883328be787499f8b842d