### PR TITLE
Add warning when push permission granted but disabled

### DIFF
--- a/assets/push-button.js
+++ b/assets/push-button.js
@@ -16,10 +16,25 @@
     if(btn) btn.textContent = enabled ? disableLabel : enableLabel;
   }
 
+  const registrationWarning = 'Service worker registration failed – check /OneSignalSDKWorker.js';
+
   function refresh(){
     OneSignal.push(function(){
       OneSignal.isPushNotificationsEnabled(function(enabled){
         updateUI(enabled);
+
+        if(typeof Notification !== 'undefined' && Notification.permission === 'granted' && !enabled){
+          console.warn(registrationWarning);
+
+          if(status){
+            const current = status.textContent || '';
+            if(current.indexOf(registrationWarning) === -1){
+              status.textContent = current
+                ? current + ' (' + registrationWarning + ')'
+                : registrationWarning;
+            }
+          }
+        }
       });
     });
   }


### PR DESCRIPTION
## Summary
- log a warning when push notifications remain disabled despite granted permission
- surface the likely service worker registration failure so the enable button state is understood

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c83132e5088332be65310fcb7eea3b