### PR TITLE
Update OneSignal updater worker path and rewrites

### DIFF
--- a/assets/onesignal-init.js
+++ b/assets/onesignal-init.js
@@ -23,7 +23,7 @@
       appId: WCOF_PUSH.appId,
       serviceWorkerParam: { scope: '/' },
       serviceWorkerPath: '/OneSignalSDKWorker.js',
-      serviceWorkerUpdaterPath: '/OneSignalSDKUpdaterWorker.js',
+      serviceWorkerUpdaterPath: '/UpdaterWorker.js',
       allowLocalhostAsSecureOrigin: true,
       notifyButton: { enable: false }
     });


### PR DESCRIPTION
## Summary
- update the OneSignal init script to request the new updater worker URL
- add a rewrite target for UpdaterWorker.js and guard against canonical redirects
- flush rewrite rules on upgrade so the new worker path is recognized

## Testing
- php -l wc-order-flow.php

------
https://chatgpt.com/codex/tasks/task_e_68c8ad07b9ac8332b72fb63181f1f947