### PR TITLE
Update OneSignal updater worker path

### DIFF
--- a/assets/onesignal-init.js
+++ b/assets/onesignal-init.js
@@ -23,7 +23,7 @@
       appId: WCOF_PUSH.appId,
       serviceWorkerParam: { scope: '/' },
       serviceWorkerPath: '/OneSignalSDKWorker.js',
-      serviceWorkerUpdaterPath: '/UpdaterWorker.js',
+      serviceWorkerUpdaterPath: '/OneSignalSDKUpdaterWorker.js',
       allowLocalhostAsSecureOrigin: true,
       notifyButton: { enable: false }
     });


### PR DESCRIPTION
## Summary
- point the OneSignal updater worker registration at the OneSignalSDKUpdaterWorker.js file to match the rewrite rule

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8b6a691f48332a33b8718cef431c0