### PR TITLE
Add OneSignal logging to script loading and push button

### DIFF
--- a/assets/onesignal-init.js
+++ b/assets/onesignal-init.js
@@ -16,7 +16,18 @@
   var s = document.createElement('script');
   s.src = 'https://cdn.onesignal.com/sdks/OneSignalSDK.js';
   s.async = true;
-  document.head.appendChild(s);
+  try {
+    document.head.appendChild(s);
+    console.log('[OneSignal] SDK script tag appended to <head>.');
+  } catch (error) {
+    console.error('[OneSignal] Failed to append SDK script tag to <head>.', error);
+  }
+  s.addEventListener('load', function(){
+    console.log('[OneSignal] SDK script loaded successfully.');
+  });
+  s.addEventListener('error', function(event){
+    console.error('[OneSignal] SDK script failed to load.', event);
+  });
 
   OneSignal.push(function() {
     OneSignal.init({

--- a/assets/push-button.js
+++ b/assets/push-button.js
@@ -55,6 +55,7 @@
 
   if(btn){
     btn.addEventListener('click', function(){
+      console.log('[OneSignal] Push button clicked; queuing subscription check.');
       OneSignal.push(function(){
         OneSignal.isPushNotificationsEnabled(function(enabled){
           if(enabled){


### PR DESCRIPTION
## Summary
- add console logging when the OneSignal SDK script tag is appended and when it loads or errors
- log OneSignal push button clicks before queuing SDK calls

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8b6a672d88332adc86bfcb66a8a73