### PR TITLE
Ensure wp-interactivity script is enqueued

### DIFF
--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -118,8 +118,10 @@ final class WCOF_Plugin {
         add_action('admin_init', [$this,'register_settings']);
         add_action('admin_init', [$this,'maybe_redirect_setup']);
         add_action('admin_post_wcof_finish_setup', [$this,'handle_finish_setup']);
+        add_action('wp_enqueue_scripts', [$this,'ensure_interactivity_module'], 5);
         add_action('wp_enqueue_scripts', [$this,'maybe_inject_onesignal_sdk']);
         add_action('wp_enqueue_scripts', [$this,'enqueue_checkout_scripts']);
+        add_action('admin_enqueue_scripts', [$this,'ensure_interactivity_module'], 5);
         add_filter('woocommerce_shipping_methods', [$this,'register_shipping_method']);
         add_action('admin_enqueue_scripts', [$this,'admin_scripts']);
 
@@ -1780,6 +1782,22 @@ exit;
         }
         fclose($out);
         exit;
+    }
+
+    public function ensure_interactivity_module(){
+        if( !function_exists('wp_enqueue_script') ) return;
+
+        if( function_exists('wp_script_is') && wp_script_is('wp-interactivity', 'registered') ){
+            wp_enqueue_script('wp-interactivity');
+            return;
+        }
+
+        if( function_exists('wp_scripts') ){
+            $scripts = wp_scripts();
+            if( $scripts && isset($scripts->registered['wp-interactivity']) ){
+                wp_enqueue_script('wp-interactivity');
+            }
+        }
     }
 
     /* ===== OneSignal init + push senders ===== */


### PR DESCRIPTION
## Summary
- ensure the plugin enqueues WordPress' wp-interactivity script so the @wordpress/interactivity module can resolve on the front end and admin screens

## Testing
- php -l wc-order-flow.php

------
https://chatgpt.com/codex/tasks/task_e_68c8b6a51c448332bec5beee98681352