### PR TITLE
Route push notifications to appropriate recipients

### DIFF
--- a/languages/wc-order-flow-en_US.po
+++ b/languages/wc-order-flow-en_US.po
@@ -18,3 +18,6 @@ msgstr "Install prompt text"
 
 msgid "Add this page to your home screen via your browser menu"
 msgstr "Add this page to your home screen via your browser menu"
+
+msgid "Customer"
+msgstr "Customer"

--- a/languages/wc-order-flow-es_ES.po
+++ b/languages/wc-order-flow-es_ES.po
@@ -189,6 +189,9 @@ msgstr "Admin"
 msgid "User"
 msgstr "Usuario"
 
+msgid "Customer"
+msgstr "Cliente"
+
 msgid "Approved"
 msgstr "Aprobado"
 

--- a/languages/wc-order-flow-it_IT.po
+++ b/languages/wc-order-flow-it_IT.po
@@ -189,6 +189,9 @@ msgstr "Admin"
 msgid "User"
 msgstr "Utente"
 
+msgid "Customer"
+msgstr "Cliente"
+
 msgid "Approved"
 msgstr "Approvato"
 


### PR DESCRIPTION
## Summary
- target new-order notifications to WooCommerce managers by resolving their OneSignal external IDs
- deliver order-approved notifications exclusively to riders and keep out-for-delivery updates focused on the ordering customer
- surface the new rider/customer notification mapping in the settings UI and extend translations accordingly

## Testing
- php -l wc-order-flow.php

------
https://chatgpt.com/codex/tasks/task_e_68c8be5a46708332a0d3a77e5d9e8ca2