### PR TITLE
Allow push debug shortcode for all users

### DIFF
--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -2174,7 +2174,6 @@ exit;
         <?php return ob_get_clean();
     }
     public function shortcode_push_debug($atts=[]){
-        if(!current_user_can('manage_woocommerce')) return '';
         if( !$this->is_license_valid() ) return '<em>License invalid.</em>';
         if( empty($this->settings()['enable']) ) return '<em>Enable push in settings first.</em>';
         wp_enqueue_script('wcof-push-debug', plugins_url('assets/push-debug.js', __FILE__), [], '1.9.0', true);


### PR DESCRIPTION
## Summary
- remove the manage_woocommerce capability restriction from the push debug shortcode so it renders for all users

## Testing
- php -l wc-order-flow.php

------
https://chatgpt.com/codex/tasks/task_e_68ca72e9f7f883329cf2e961320edfc4