### PR TITLE
Improve push permission prompts on unsupported browsers

### DIFF
--- a/assets/onesignal-init.js
+++ b/assets/onesignal-init.js
@@ -41,6 +41,30 @@
     return String(parsed);
   }
 
+  function requestPushPermission(){
+    try {
+      var api = window.OneSignal || null;
+      if (api && api.Notifications && typeof api.Notifications.requestPermission === 'function') {
+        api.Notifications.requestPermission(true);
+        return;
+      }
+      if (api && api.Slidedown && typeof api.Slidedown.promptPush === 'function') {
+        api.Slidedown.promptPush();
+        return;
+      }
+      if (api && typeof api.showSlidedownPrompt === 'function') {
+        api.showSlidedownPrompt();
+        return;
+      }
+      if (api && typeof api.registerForPushNotifications === 'function') {
+        api.registerForPushNotifications({ modalPrompt: true });
+      }
+    } catch (error) {
+      console.error('[OneSignal] Failed to request push permission.', error);
+    }
+  }
+  window.wcofRequestPushPermission = requestPushPermission;
+
   OneSignal.push(function() {
     OneSignal.init({
       appId: WCOF_PUSH.appId,
@@ -71,7 +95,7 @@
 
   // automatic prompt on first click, but we also provide a manual button
   document.addEventListener('click', function once(){
-    OneSignal.push(function(){ OneSignal.showSlidedownPrompt(); });
+    OneSignal.push(requestPushPermission);
     document.removeEventListener('click', once);
   });
 })();

--- a/assets/push-button.js
+++ b/assets/push-button.js
@@ -32,8 +32,45 @@
 
   const registrationWarning = 'Service worker registration failed – check /OneSignalSDKWorker.js and /OneSignalSDKUpdaterWorker.js';
 
+  function requestPushPermission(){
+    if (typeof window.wcofRequestPushPermission === 'function') {
+      window.wcofRequestPushPermission();
+      return;
+    }
+    try {
+      var api = window.OneSignal || null;
+      if (api && api.Notifications && typeof api.Notifications.requestPermission === 'function') {
+        api.Notifications.requestPermission(true);
+        return;
+      }
+      if (api && api.Slidedown && typeof api.Slidedown.promptPush === 'function') {
+        api.Slidedown.promptPush();
+        return;
+      }
+      if (api && typeof api.showSlidedownPrompt === 'function') {
+        api.showSlidedownPrompt();
+        return;
+      }
+      if (api && typeof api.registerForPushNotifications === 'function') {
+        api.registerForPushNotifications({ modalPrompt: true });
+      }
+    } catch (error) {
+      console.error('[OneSignal] Failed to request push permission from button click.', error);
+    }
+  }
+
   function refresh(){
     OneSignal.push(function(){
+      if(typeof Notification === 'undefined'){
+        updateUI(false);
+        if(status){
+          status.textContent = 'Push notifications are not supported on this device.';
+        }
+        if(btn){
+          btn.disabled = true;
+        }
+        return;
+      }
       OneSignal.isPushNotificationsEnabled(function(enabled){
         updateUI(enabled);
 
@@ -56,6 +93,13 @@
   if(btn){
     btn.addEventListener('click', function(){
       console.log('[OneSignal] Push button clicked; queuing subscription check.');
+      if(typeof Notification === 'undefined'){
+        if(status){
+          status.textContent = 'Push notifications are not supported on this device.';
+        }
+        console.warn('[OneSignal] Notifications API is not available in this browser.');
+        return;
+      }
       OneSignal.push(function(){
         OneSignal.isPushNotificationsEnabled(function(enabled){
           if(enabled){
@@ -64,14 +108,20 @@
             if(window.WCOF_PUSH && WCOF_PUSH.userId){
               OneSignal.setExternalUserId(String(WCOF_PUSH.userId));
             }
-            if(Notification.permission === 'granted'){
+            var permission = (typeof Notification !== 'undefined' && Notification.permission) ? Notification.permission : 'default';
+            if(permission === 'granted'){
               if(typeof OneSignal.registerForPushNotifications === 'function'){
                 OneSignal.registerForPushNotifications();
               } else {
                 OneSignal.setSubscription(true);
               }
+            } else if(permission === 'denied'){
+              if(status){
+                status.textContent = 'Push notifications are blocked in your browser settings.';
+              }
+              console.warn('[OneSignal] Notification permission previously denied by the user.');
             } else {
-              OneSignal.showSlidedownPrompt();
+              requestPushPermission();
             }
           }
         });

--- a/assets/push-debug.js
+++ b/assets/push-debug.js
@@ -2,6 +2,33 @@
   const root = document.getElementById('wcof-push-debug');
   if(!root) return;
   function line(k,v){ return `<div><strong>${k}:</strong> <code>${String(v)}</code></div>`; }
+  function requestPushPermission(){
+    if (typeof window.wcofRequestPushPermission === 'function') {
+      window.wcofRequestPushPermission();
+      return;
+    }
+    try {
+      var api = window.OneSignal || null;
+      if (api && api.Notifications && typeof api.Notifications.requestPermission === 'function') {
+        api.Notifications.requestPermission(true);
+        return;
+      }
+      if (api && api.Slidedown && typeof api.Slidedown.promptPush === 'function') {
+        api.Slidedown.promptPush();
+        return;
+      }
+      if (api && typeof api.showSlidedownPrompt === 'function') {
+        api.showSlidedownPrompt();
+        return;
+      }
+      if (api && typeof api.registerForPushNotifications === 'function') {
+        api.registerForPushNotifications({ modalPrompt: true });
+      }
+    } catch (error) {
+      console.error('[OneSignal] Failed to request push permission from debug tools.', error);
+    }
+  }
+
   function render(info){
     root.innerHTML = `
       <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px">
@@ -15,7 +42,7 @@
       ${line('External User ID', info.externalId)}
       ${line('Tags', JSON.stringify(info.tags||{}))}
     `;
-    document.getElementById('wcof-btn-prompt').onclick = function(){ OneSignal.showSlidedownPrompt(); };
+    document.getElementById('wcof-btn-prompt').onclick = requestPushPermission;
     document.getElementById('wcof-btn-refresh').onclick = load;
     document.getElementById('wcof-btn-unsub').onclick = function(){ OneSignal.setSubscription(false); setTimeout(load,600); };
   }


### PR DESCRIPTION
## Summary
- add a reusable helper that requests push permission using the newest OneSignal APIs with graceful fallbacks
- guard the subscription button when the Notifications API is missing and surface clearer status messaging
- update the debug tools and automatic prompt to rely on the shared helper for consistent behaviour on mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca754fc5348332bc1a2dd263a4299e