### PR TITLE
Adjust OneSignal service worker paths for subdirectory installs

### DIFF
--- a/assets/onesignal-init.js
+++ b/assets/onesignal-init.js
@@ -33,6 +33,13 @@
     return value === true || value === 1 || value === '1';
   }
 
+  function stringOrDefault(value, fallback) {
+    if (typeof value === 'string' && value) {
+      return value;
+    }
+    return fallback;
+  }
+
   function normalizeUserId(value) {
     var parsed = parseInt(value, 10);
     if (isNaN(parsed) || parsed <= 0) {
@@ -65,12 +72,16 @@
   }
   window.wcofRequestPushPermission = requestPushPermission;
 
+  var serviceWorkerScope = stringOrDefault(WCOF_PUSH.swScope, '/');
+  var serviceWorkerPath = stringOrDefault(WCOF_PUSH.swWorkerPath, '/OneSignalSDKWorker.js');
+  var serviceWorkerUpdaterPath = stringOrDefault(WCOF_PUSH.swUpdaterPath, '/OneSignalSDKUpdaterWorker.js');
+
   OneSignal.push(function() {
     OneSignal.init({
       appId: WCOF_PUSH.appId,
-      serviceWorkerParam: { scope: '/' },
-      serviceWorkerPath: '/OneSignalSDKWorker.js',
-      serviceWorkerUpdaterPath: '/OneSignalSDKUpdaterWorker.js',
+      serviceWorkerParam: { scope: serviceWorkerScope },
+      serviceWorkerPath: serviceWorkerPath,
+      serviceWorkerUpdaterPath: serviceWorkerUpdaterPath,
       allowLocalhostAsSecureOrigin: true,
       notifyButton: { enable: false }
     });

--- a/wc-order-flow.php
+++ b/wc-order-flow.php
@@ -1802,12 +1802,26 @@ exit;
         if( !$this->is_license_valid() ) return;
         $s = $this->settings();
         if( empty($s['enable']) || empty($s['app_id']) ) return;
+        $public_path = wp_parse_url(home_url('/'), PHP_URL_PATH);
+        if (!is_string($public_path) || $public_path === '') {
+            $public_path = '/';
+        } else {
+            $public_path = '/' . ltrim($public_path, '/');
+            $public_path = trailingslashit($public_path);
+        }
+        if ($public_path === '') {
+            $public_path = '/';
+        }
+
         wp_enqueue_script('wcof-onesignal', plugins_url('assets/onesignal-init.js', __FILE__), [], '1.9.0', true);
         wp_localize_script('wcof-onesignal', 'WCOF_PUSH', [
-            'appId'   => $s['app_id'],
-            'userId'  => get_current_user_id(),
-            'isAdmin' => current_user_can('manage_woocommerce') ? 1 : 0,
-            'isRider' => current_user_can('wcof_rider') ? 1 : 0,
+            'appId'           => $s['app_id'],
+            'userId'          => get_current_user_id(),
+            'isAdmin'         => current_user_can('manage_woocommerce') ? 1 : 0,
+            'isRider'         => current_user_can('wcof_rider') ? 1 : 0,
+            'swScope'         => $public_path,
+            'swWorkerPath'    => $public_path . 'OneSignalSDKWorker.js',
+            'swUpdaterPath'   => $public_path . 'OneSignalSDKUpdaterWorker.js',
         ]);
     }
 


### PR DESCRIPTION
## Summary
- derive the public path from the site home URL and expose it to the OneSignal bootstrap script so service worker URLs are correctly scoped
- update the OneSignal initialization script to respect localized service worker scope and paths while keeping the previous defaults

## Testing
- php -l wc-order-flow.php
- node - <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68ca7a75617083328fc3d65117ad5090