### PR TITLE
Fix OneSignal subscription flow and debug tools

### DIFF
--- a/assets/onesignal-init.js
+++ b/assets/onesignal-init.js
@@ -29,6 +29,51 @@
     console.error('[OneSignal] SDK script failed to load.', event);
   });
 
+  function ensureQueue(){
+    if(!window.OneSignal) window.OneSignal = [];
+  }
+
+  function withOneSignal(callback){
+    ensureQueue();
+    return new Promise(function(resolve){
+      var execute = function(){
+        try {
+          var result = callback(window.OneSignal);
+          if(result && typeof result.then === 'function'){
+            result.then(resolve).catch(function(error){
+              console.error('[OneSignal] Callback rejected.', error);
+              resolve();
+            });
+          } else {
+            resolve(result);
+          }
+        } catch (error) {
+          console.error('[OneSignal] Callback threw an error.', error);
+          resolve();
+        }
+      };
+      if(typeof window.OneSignal.push === 'function' && window.OneSignal.push !== Array.prototype.push){
+        execute();
+      } else {
+        window.OneSignal.push(execute);
+      }
+    });
+  }
+
+  function resolveValue(value){
+    if(typeof value === 'function'){
+      try {
+        return resolveValue(value());
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
+    if(value && typeof value.then === 'function'){
+      return value;
+    }
+    return Promise.resolve(value);
+  }
+
   function flagIsTrue(value) {
     return value === true || value === 1 || value === '1';
   }
@@ -48,29 +93,215 @@
     return String(parsed);
   }
 
+  function setPushSubscription(target, apiInstance){
+    var desired = !!target;
+    function perform(api){
+      if(!api) return Promise.resolve(null);
+      try {
+        var pushSub = api.User && api.User.PushSubscription ? api.User.PushSubscription : null;
+        if(pushSub){
+          if(desired && typeof pushSub.optIn === 'function'){
+            return resolveValue(function(){ return pushSub.optIn(); });
+          }
+          if(!desired && typeof pushSub.optOut === 'function'){
+            return resolveValue(function(){ return pushSub.optOut(); });
+          }
+        }
+        if(typeof api.setSubscription === 'function'){
+          return resolveValue(function(){ return api.setSubscription(desired); });
+        }
+        if(desired && typeof api.registerForPushNotifications === 'function'){
+          return resolveValue(function(){ return api.registerForPushNotifications({ modalPrompt: false }); });
+        }
+      } catch (error) {
+        return Promise.reject(error);
+      }
+      return Promise.resolve(null);
+    }
+    function handle(api){
+      return perform(api).catch(function(error){
+        console.error('[OneSignal] Failed to update push subscription state.', error);
+      });
+    }
+    if(apiInstance){
+      return handle(apiInstance);
+    }
+    return withOneSignal(handle);
+  }
+
+  function fetchPushInfo(){
+    return withOneSignal(function(api){
+      var pushSub = api && api.User && api.User.PushSubscription ? api.User.PushSubscription : null;
+
+      var permissionPromise = resolveValue(function(){
+        if(api && api.Notifications){
+          if(typeof api.Notifications.permission === 'function' || typeof api.Notifications.permission === 'string'){
+            return api.Notifications.permission;
+          }
+          if(typeof api.Notifications.getPermission === 'function'){
+            return api.Notifications.getPermission();
+          }
+        }
+        if(typeof api.getNotificationPermission === 'function'){
+          return api.getNotificationPermission();
+        }
+        if(typeof Notification !== 'undefined'){
+          return Notification.permission;
+        }
+        return 'default';
+      }).catch(function(error){
+        console.error('[OneSignal] Failed to read notification permission.', error);
+        return typeof Notification !== 'undefined' ? Notification.permission : 'default';
+      });
+
+      var enabledPromise = resolveValue(function(){
+        if(pushSub){
+          if(typeof pushSub.optedIn === 'function'){
+            return pushSub.optedIn();
+          }
+          if(typeof pushSub.optedIn !== 'undefined'){
+            return !!pushSub.optedIn;
+          }
+        }
+        if(api && api.Notifications && typeof api.Notifications.isSubscribed === 'function'){
+          return api.Notifications.isSubscribed();
+        }
+        if(typeof api.isPushNotificationsEnabled === 'function'){
+          return new Promise(function(resolve){ api.isPushNotificationsEnabled(resolve); });
+        }
+        return false;
+      }).catch(function(error){
+        console.error('[OneSignal] Failed to determine push subscription status.', error);
+        return false;
+      });
+
+      var userIdPromise = resolveValue(function(){
+        if(pushSub){
+          if(typeof pushSub.id === 'function'){
+            return pushSub.id();
+          }
+          if(typeof pushSub.id !== 'undefined'){
+            return pushSub.id;
+          }
+        }
+        if(typeof api.getUserId === 'function'){
+          return api.getUserId();
+        }
+        return null;
+      }).catch(function(error){
+        console.error('[OneSignal] Failed to get OneSignal user ID.', error);
+        return null;
+      });
+
+      var externalIdPromise = resolveValue(function(){
+        if(api && api.User && api.User.ExternalId && typeof api.User.ExternalId.get === 'function'){
+          return api.User.ExternalId.get();
+        }
+        if(typeof api.getExternalUserId === 'function'){
+          return api.getExternalUserId();
+        }
+        return null;
+      }).catch(function(error){
+        console.error('[OneSignal] Failed to get external user ID.', error);
+        return null;
+      });
+
+      var tagsPromise = resolveValue(function(){
+        if(api && api.User && api.User.Tags){
+          if(typeof api.User.Tags.getTags === 'function'){
+            return api.User.Tags.getTags();
+          }
+          if(typeof api.User.Tags.getAll === 'function'){
+            return api.User.Tags.getAll();
+          }
+        }
+        if(typeof api.getTags === 'function'){
+          return api.getTags();
+        }
+        return {};
+      }).catch(function(error){
+        console.error('[OneSignal] Failed to get OneSignal tags.', error);
+        return {};
+      });
+
+      return Promise.all([permissionPromise, enabledPromise, userIdPromise, externalIdPromise, tagsPromise]).then(function(values){
+        var tags = values[4];
+        if(!tags || typeof tags !== 'object'){
+          tags = {};
+        }
+        return {
+          permission: values[0] || (typeof Notification !== 'undefined' ? Notification.permission : 'default'),
+          enabled: !!values[1],
+          userId: values[2] || null,
+          externalId: values[3] || null,
+          tags: tags
+        };
+      });
+    });
+  }
+
   function requestPushPermission(){
     try {
-      var api = window.OneSignal || null;
-      if (api && api.Notifications && typeof api.Notifications.requestPermission === 'function') {
-        api.Notifications.requestPermission(true);
-        return;
-      }
-      if (api && api.Slidedown && typeof api.Slidedown.promptPush === 'function') {
-        api.Slidedown.promptPush();
-        return;
-      }
-      if (api && typeof api.showSlidedownPrompt === 'function') {
-        api.showSlidedownPrompt();
-        return;
-      }
-      if (api && typeof api.registerForPushNotifications === 'function') {
-        api.registerForPushNotifications({ modalPrompt: true });
-      }
+      withOneSignal(function(api){
+        if(!api) return;
+        if(api.Notifications && typeof api.Notifications.requestPermission === 'function'){
+          var result = null;
+          try {
+            result = api.Notifications.requestPermission(true);
+          } catch (err) {
+            console.error('[OneSignal] Failed to request permission via Notifications.requestPermission.', err);
+          }
+          var ensureSubscribed = function(outcome){
+            var granted = false;
+            if(outcome === 'granted' || outcome === true){
+              granted = true;
+            } else if(outcome && typeof outcome === 'object'){
+              if(outcome.state === 'granted' || outcome.permission === 'granted' || outcome.to === 'granted'){
+                granted = true;
+              }
+            }
+            if(!granted && typeof Notification !== 'undefined' && Notification.permission === 'granted'){
+              granted = true;
+            }
+            if(granted){
+              setPushSubscription(true, api);
+            }
+          };
+          if(result && typeof result.then === 'function'){
+            result.then(ensureSubscribed).catch(function(error){
+              console.error('[OneSignal] Permission request promise rejected.', error);
+              ensureSubscribed(null);
+            });
+          } else {
+            ensureSubscribed(result);
+          }
+          return;
+        }
+        if(api.Slidedown && typeof api.Slidedown.promptPush === 'function'){
+          api.Slidedown.promptPush();
+          return;
+        }
+        if(typeof api.showSlidedownPrompt === 'function'){
+          api.showSlidedownPrompt();
+          return;
+        }
+        if(typeof api.registerForPushNotifications === 'function'){
+          api.registerForPushNotifications({ modalPrompt: true });
+        }
+      });
     } catch (error) {
       console.error('[OneSignal] Failed to request push permission.', error);
     }
+    if(typeof Notification !== 'undefined' && Notification.permission === 'granted'){
+      setPushSubscription(true);
+    }
   }
+
   window.wcofRequestPushPermission = requestPushPermission;
+  window.wcofSetPushSubscription = function(enabled){
+    return setPushSubscription(enabled);
+  };
+  window.wcofFetchPushInfo = fetchPushInfo;
 
   var serviceWorkerScope = stringOrDefault(WCOF_PUSH.swScope, '/');
   var serviceWorkerPath = stringOrDefault(WCOF_PUSH.swWorkerPath, '/OneSignalSDKWorker.js');
@@ -102,11 +333,29 @@
     if (externalId) {
       OneSignal.setExternalUserId(externalId);
     }
+
+    try {
+      if(OneSignal.Notifications && typeof OneSignal.Notifications.addEventListener === 'function'){
+        OneSignal.Notifications.addEventListener('permissionChange', function(event){
+          if(event && (event.to === 'granted' || event.permission === 'granted')){
+            setPushSubscription(true, OneSignal);
+          }
+        });
+      } else if (typeof OneSignal.on === 'function') {
+        OneSignal.on('notificationPermissionChange', function(permissionChange){
+          if(permissionChange && permissionChange.to === 'granted'){
+            setPushSubscription(true, OneSignal);
+          }
+        });
+      }
+    } catch (error) {
+      console.error('[OneSignal] Failed to attach permission change listener.', error);
+    }
   });
 
   // automatic prompt on first click, but we also provide a manual button
   document.addEventListener('click', function once(){
-    OneSignal.push(requestPushPermission);
+    requestPushPermission();
     document.removeEventListener('click', once);
   });
 })();

--- a/assets/push-debug.js
+++ b/assets/push-debug.js
@@ -1,35 +1,107 @@
 (function(){
   const root = document.getElementById('wcof-push-debug');
   if(!root) return;
-  function line(k,v){ return `<div><strong>${k}:</strong> <code>${String(v)}</code></div>`; }
+
+  function line(k,v){
+    return `<div><strong>${k}:</strong> <code>${String(v)}</code></div>`;
+  }
+
   function requestPushPermission(){
     if (typeof window.wcofRequestPushPermission === 'function') {
       window.wcofRequestPushPermission();
       return;
     }
     try {
-      var api = window.OneSignal || null;
-      if (api && api.Notifications && typeof api.Notifications.requestPermission === 'function') {
-        api.Notifications.requestPermission(true);
-        return;
-      }
-      if (api && api.Slidedown && typeof api.Slidedown.promptPush === 'function') {
-        api.Slidedown.promptPush();
-        return;
-      }
-      if (api && typeof api.showSlidedownPrompt === 'function') {
-        api.showSlidedownPrompt();
-        return;
-      }
-      if (api && typeof api.registerForPushNotifications === 'function') {
-        api.registerForPushNotifications({ modalPrompt: true });
-      }
+      if(!window.OneSignal){ return; }
+      window.OneSignal.push(function(){
+        var api = window.OneSignal;
+        if (api && api.Notifications && typeof api.Notifications.requestPermission === 'function') {
+          api.Notifications.requestPermission(true);
+          return;
+        }
+        if (api && api.Slidedown && typeof api.Slidedown.promptPush === 'function') {
+          api.Slidedown.promptPush();
+          return;
+        }
+        if (api && typeof api.showSlidedownPrompt === 'function') {
+          api.showSlidedownPrompt();
+          return;
+        }
+        if (api && typeof api.registerForPushNotifications === 'function') {
+          api.registerForPushNotifications({ modalPrompt: true });
+        }
+      });
     } catch (error) {
       console.error('[OneSignal] Failed to request push permission from debug tools.', error);
     }
   }
 
+  function setSubscription(enabled){
+    if (typeof window.wcofSetPushSubscription === 'function') {
+      return window.wcofSetPushSubscription(enabled);
+    }
+    if(!window.OneSignal){ return Promise.resolve(); }
+    return new Promise(function(resolve){
+      window.OneSignal.push(function(){
+        try {
+          if(typeof window.OneSignal.setSubscription === 'function'){
+            window.OneSignal.setSubscription(!!enabled);
+          } else if (enabled && typeof window.OneSignal.registerForPushNotifications === 'function'){
+            window.OneSignal.registerForPushNotifications();
+          }
+        } finally {
+          resolve();
+        }
+      });
+    });
+  }
+
+  function fetchInfo(){
+    if (typeof window.wcofFetchPushInfo === 'function') {
+      return window.wcofFetchPushInfo().catch(function(error){
+        console.error('[OneSignal] Failed to fetch push info for debug tools.', error);
+        return null;
+      });
+    }
+    if(!window.OneSignal){
+      return Promise.resolve({
+        permission: typeof Notification !== 'undefined' ? Notification.permission : 'default',
+        enabled: false,
+        userId: null,
+        externalId: null,
+        tags: {}
+      });
+    }
+    return new Promise(function(resolve){
+      window.OneSignal.push(function(){
+        var api = window.OneSignal;
+        var getPermission = typeof api.getNotificationPermission === 'function'
+          ? api.getNotificationPermission()
+          : Promise.resolve(typeof Notification !== 'undefined' ? Notification.permission : 'default');
+        var getEnabled = typeof api.isPushNotificationsEnabled === 'function'
+          ? new Promise(function(res){ api.isPushNotificationsEnabled(res); })
+          : Promise.resolve(false);
+        var getUserId = typeof api.getUserId === 'function' ? api.getUserId() : Promise.resolve(null);
+        var getExternal = typeof api.getExternalUserId === 'function' ? api.getExternalUserId() : Promise.resolve(null);
+        var getTags = typeof api.getTags === 'function' ? api.getTags() : Promise.resolve({});
+        Promise.all([getPermission, getEnabled, getUserId, getExternal, getTags]).then(function(values){
+          resolve({
+            permission: values[0],
+            enabled: !!values[1],
+            userId: values[2],
+            externalId: values[3],
+            tags: values[4] || {}
+          });
+        }).catch(function(error){
+          console.error('[OneSignal] Failed to load debug info.', error);
+          resolve(null);
+        });
+      });
+    });
+  }
+
   function render(info){
+    info = info || { permission: 'unknown', enabled: false, userId: null, externalId: null, tags: {} };
     root.innerHTML = `
       <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px">
         <button id="wcof-btn-prompt" class="button button-primary">Prompt</button>
@@ -40,25 +112,27 @@
       ${line('Enabled', info.enabled)}
       ${line('Player ID', info.userId)}
       ${line('External User ID', info.externalId)}
-      ${line('Tags', JSON.stringify(info.tags||{}))}
+      ${line('Tags', JSON.stringify(info.tags || {}))}
     `;
     document.getElementById('wcof-btn-prompt').onclick = requestPushPermission;
     document.getElementById('wcof-btn-refresh').onclick = load;
-    document.getElementById('wcof-btn-unsub').onclick = function(){ OneSignal.setSubscription(false); setTimeout(load,600); };
-  }
-  function load(){
-    if(!window.OneSignal){ setTimeout(load,500); return; }
-    OneSignal.push(function(){
-      Promise.all([
-        OneSignal.getNotificationPermission(),
-        new Promise(res=>OneSignal.isPushNotificationsEnabled(res)),
-        OneSignal.getUserId(),
-        OneSignal.getExternalUserId ? OneSignal.getExternalUserId() : Promise.resolve(null),
-        OneSignal.getTags ? OneSignal.getTags() : Promise.resolve({})
-      ]).then(function(r){
-        render({ permission:r[0], enabled:r[1], userId:r[2], externalId:r[3], tags:r[4] });
+    document.getElementById('wcof-btn-unsub').onclick = function(){
+      Promise.resolve(setSubscription(false)).then(function(){
+        setTimeout(load, 600);
       });
+    };
+  }
+
+  function load(){
+    fetchInfo().then(function(info){
+      if(!info){
+        console.warn('[OneSignal] Debug info unavailable. Retrying…');
+        setTimeout(load, 1000);
+        return;
+      }
+      render(info);
     });
   }
+
   setTimeout(load, 1000);
 })();


### PR DESCRIPTION
## Summary
- add helper utilities to coordinate OneSignal actions across the plugin and ensure subscriptions are created when permission is granted
- update the push button logic to support both modern and legacy OneSignal APIs and improve permission handling feedback
- refresh the push debug panel to rely on the shared helpers and make unsubscribe/prompt actions functional again

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca803ecd2c833297027cb77c3dd471