### PR TITLE
Add standalone PWA service worker registration

### DIFF
--- a/assets/pwa-worker.js
+++ b/assets/pwa-worker.js
@@ -1,0 +1,78 @@
+const CACHE_PREFIX = 'wcof-pwa-cache-';
+const CACHE_VERSION = 'v1';
+const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
+
+self.addEventListener('install', function(event) {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(function(cache) {
+      return cache.addAll([]);
+    }).catch(function() {
+      return Promise.resolve();
+    })
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function(event) {
+  event.waitUntil(
+    caches.keys().then(function(keys) {
+      return Promise.all(
+        keys
+          .filter(function(key) {
+            return key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME;
+          })
+          .map(function(key) {
+            return caches.delete(key);
+          })
+      );
+    }).catch(function() {
+      return Promise.resolve();
+    })
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', function(event) {
+  var request = event.request;
+  if (!request || request.method !== 'GET') {
+    return;
+  }
+
+  var requestUrl;
+  try {
+    requestUrl = new URL(request.url);
+  } catch (error) {
+    return;
+  }
+
+  if (requestUrl.origin !== self.location.origin) {
+    return;
+  }
+
+  event.respondWith(
+    fetch(request)
+      .then(function(response) {
+        if (!response || response.status !== 200 || response.type !== 'basic') {
+          return response;
+        }
+
+        var responseToCache = response.clone();
+        caches.open(CACHE_NAME).then(function(cache) {
+          cache.put(request, responseToCache).catch(function() {});
+        }).catch(function() {});
+
+        return response;
+      })
+      .catch(function() {
+        return caches.match(request).then(function(cacheResponse) {
+          if (cacheResponse) {
+            return cacheResponse;
+          }
+          return new Response('', {
+            status: 504,
+            statusText: 'Gateway Timeout'
+          });
+        });
+      })
+  );
+});


### PR DESCRIPTION
## Summary
- expose a dedicated `/wcof-pwa-worker.js` rewrite when the PWA banner is enabled and pass its URL/scope to the front end
- add a lightweight caching service worker script that satisfies install criteria without depending on OneSignal
- update the PWA banner script to register the worker before wiring the install prompt logic

## Testing
- php -l wc-order-flow.php

------
https://chatgpt.com/codex/tasks/task_e_68cbe013f63883329c717261b37a6264