### PR TITLE
Add navigation service worker with offline support

### DIFF
--- a/assets/pwa-worker-disabled.js
+++ b/assets/pwa-worker-disabled.js
@@ -1,0 +1,50 @@
+const CACHE_PREFIX = __CACHE_PREFIX__;
+
+self.addEventListener('install', function(event) {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function(event) {
+  event.waitUntil(
+    caches.keys().then(function(keys) {
+      return Promise.all(
+        keys
+          .filter(function(key) {
+            return key.startsWith(CACHE_PREFIX);
+          })
+          .map(function(key) {
+            return caches.delete(key);
+          })
+      );
+    }).catch(function() {
+      return Promise.resolve();
+    }).then(function() {
+      if (self.registration && self.registration.unregister) {
+        return self.registration.unregister();
+      }
+      return true;
+    }).then(function() {
+      if (!self.clients || !self.clients.matchAll) {
+        return true;
+      }
+      return self.clients.matchAll({ type: 'window' }).then(function(clients) {
+        if (!clients || !clients.length) {
+          return true;
+        }
+        var reloads = [];
+        for (var i = 0; i < clients.length; i++) {
+          var client = clients[i];
+          if (client && typeof client.navigate === 'function') {
+            reloads.push(client.navigate(client.url).catch(function() {}));
+          }
+        }
+        if (reloads.length) {
+          return Promise.all(reloads);
+        }
+        return true;
+      });
+    }).catch(function() {
+      return Promise.resolve();
+    })
+  );
+});

--- a/assets/pwa-worker.js
+++ b/assets/pwa-worker.js
@@ -1,11 +1,16 @@
-const CACHE_PREFIX = 'wcof-pwa-cache-';
-const CACHE_VERSION = 'v1';
+const CACHE_PREFIX = __CACHE_PREFIX__;
+const CACHE_VERSION = __CACHE_VERSION__;
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
+const START_URL = __START_URL__;
+const OFFLINE_HTML = __OFFLINE_HTML__;
+const OFFLINE_RESPONSE = new Response(OFFLINE_HTML, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
 
 self.addEventListener('install', function(event) {
   event.waitUntil(
     caches.open(CACHE_NAME).then(function(cache) {
-      return cache.addAll([]);
+      return cache.addAll([START_URL]).catch(function() {
+        return Promise.resolve();
+      });
     }).catch(function() {
       return Promise.resolve();
     })
@@ -27,9 +32,10 @@ self.addEventListener('activate', function(event) {
       );
     }).catch(function() {
       return Promise.resolve();
+    }).then(function() {
+      return self.clients.claim();
     })
   );
-  self.clients.claim();
 });
 
 self.addEventListener('fetch', function(event) {
@@ -38,39 +44,50 @@ self.addEventListener('fetch', function(event) {
     return;
   }
 
-  var requestUrl;
+  var url;
   try {
-    requestUrl = new URL(request.url);
+    url = new URL(request.url);
   } catch (error) {
     return;
   }
 
-  if (requestUrl.origin !== self.location.origin) {
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  var accept = request.headers && request.headers.get ? request.headers.get('accept') || '' : '';
+  var isNavigation = request.mode === 'navigate' || accept.indexOf('text/html') !== -1;
+
+  if (!isNavigation) {
     return;
   }
 
   event.respondWith(
     fetch(request)
       .then(function(response) {
-        if (!response || response.status !== 200 || response.type !== 'basic') {
-          return response;
+        if (response && response.status === 200 && (response.type === 'basic' || response.type === 'default')) {
+          var cacheCopy = response.clone();
+          var startCopy = request.mode === 'navigate' ? response.clone() : null;
+
+          caches.open(CACHE_NAME).then(function(cache) {
+            cache.put(request, cacheCopy).catch(function() {});
+            if (startCopy) {
+              cache.put(START_URL, startCopy).catch(function() {});
+            }
+          }).catch(function() {});
         }
-
-        var responseToCache = response.clone();
-        caches.open(CACHE_NAME).then(function(cache) {
-          cache.put(request, responseToCache).catch(function() {});
-        }).catch(function() {});
-
         return response;
       })
       .catch(function() {
-        return caches.match(request).then(function(cacheResponse) {
-          if (cacheResponse) {
-            return cacheResponse;
+        return caches.match(request).then(function(match) {
+          if (match) {
+            return match;
           }
-          return new Response('', {
-            status: 504,
-            statusText: 'Gateway Timeout'
+          return caches.match(START_URL).then(function(fallback) {
+            if (fallback) {
+              return fallback;
+            }
+            return OFFLINE_RESPONSE.clone();
           });
         });
       })


### PR DESCRIPTION
## Summary
- add a root-level rewrite for `wcof-navigation-worker.js` and render the PWA service worker dynamically to support offline navigation caching or clean unregistration when disabled
- extend the rewrite flush logic and localized script payload to ship the versioned navigation worker URL and scope
- refresh the front-end PWA banner script to validate the worker URL and register the service worker after load

## Testing
- php -l wc-order-flow.php

------
https://chatgpt.com/codex/tasks/task_e_68cbf8ca64188332ab447c5684335cc3